### PR TITLE
Issue #IQ-274 feat: updating latest published version of release-5.4.0

### DIFF
--- a/projects/quml-library/package-lock.json
+++ b/projects/quml-library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player",
-  "version": "5.3.0-beta.3",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/quml-library/package.json
+++ b/projects/quml-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player",
-  "version": "5.4.0-beta.4",
+  "version": "5.4.0",
   "schematics": "./schematics/collection.json",
   "ng-add": {
     "save": "dependencies"


### PR DESCRIPTION
npm version 5.4.0 is published via the [old repo](https://github.com/project-sunbird/sunbird-quml-player/blob/release-5.4.0/projects/quml-library/package.json), https://www.npmjs.com/package/@project-sunbird/sunbird-quml-player/v/5.4.0
Updating the latest published version in package.json