### PR TITLE
feat: improve question navigation logic to prevent unnecessary data f…

### DIFF
--- a/projects/quml-library/src/lib/ordered/ordered.component.scss
+++ b/projects/quml-library/src/lib/ordered/ordered.component.scss
@@ -88,6 +88,17 @@
   font-size: 1rem;
   color: #222;
   p { margin: 0; }
+
+  // SEQ item images (rendered via innerHTML) have no inherent cap, so each
+  // renders at its natural size and a wide image dominates the card while
+  // others stay small. Cap to a uniform height so every card lines up.
+  ::ng-deep img {
+    max-width: 100%;
+    max-height: 6rem;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+  }
 }
 
 // ════════════════════════════════════════════════════════

--- a/projects/quml-library/src/lib/section-player/section-player.component.spec.ts
+++ b/projects/quml-library/src/lib/section-player/section-player.component.spec.ts
@@ -222,7 +222,7 @@ describe('SectionPlayerComponent', () => {
     expect(component.setImageZoom).toHaveBeenCalled();
   }));
 
-  it('should fetch when jumping to a not-yet-loaded question', fakeAsync(() => {
+  it('should fetch and defer slide/zoom to the subscription when jumping to a not-yet-loaded question', fakeAsync(() => {
     component.myCarousel = jasmine.createSpyObj("CarouselComponent", { selectSlide: {}, getCurrentSlideIndex: 1 });
     component.questions = [];
     spyOn(viewerService, 'getQuestions');
@@ -231,7 +231,10 @@ describe('SectionPlayerComponent', () => {
     component.goToQuestion({ questionNo: 1 });
     tick();
     expect(viewerService.getQuestions).toHaveBeenCalledWith(0, 1);
+    // Fetch path returns early: the qumlQuestionEvent subscription handles these.
     expect(component.myCarousel.selectSlide).not.toHaveBeenCalled();
+    expect(component.setImageZoom).not.toHaveBeenCalled();
+    expect(component.highlightQuestion).not.toHaveBeenCalled();
   }));
 
   it('should navigate to previous slide', () => {
@@ -854,7 +857,9 @@ describe('SectionPlayerComponent', () => {
     spyOn(component, 'highlightQuestion');
     component.goToQuestion({ questionNo: 2 });
     expect(viewerService.getQuestions).toHaveBeenCalled();
-    expect(component.highlightQuestion).toHaveBeenCalled();
+    // Fetch path returns early; highlightQuestion is handled by the
+    // qumlQuestionEvent subscription once the questions arrive.
+    expect(component.highlightQuestion).not.toHaveBeenCalled();
   });
 
   it('should hight light the question on click of question', () => {

--- a/projects/quml-library/src/lib/section-player/section-player.component.spec.ts
+++ b/projects/quml-library/src/lib/section-player/section-player.component.spec.ts
@@ -207,6 +207,33 @@ describe('SectionPlayerComponent', () => {
     expect(component.clearTimeInterval).toHaveBeenCalled();
   });
 
+  it('should select slide, set media and run setImageZoom when jumping to an already-loaded question (review)', fakeAsync(() => {
+    component.myCarousel = jasmine.createSpyObj("CarouselComponent", { selectSlide: {}, getCurrentSlideIndex: 1 });
+    component.questions = mockSectionQuestions;
+    spyOn(viewerService, 'getQuestions');
+    spyOn(component, 'setImageZoom');
+    spyOn(component, 'highlightQuestion');
+    component.goToQuestion({ questionNo: 1 });
+    tick();
+    expect(component.currentSlideIndex).toBe(1);
+    expect(viewerService.getQuestions).not.toHaveBeenCalled();
+    expect(component.myCarousel.selectSlide).toHaveBeenCalledWith(1);
+    expect(component.currentQuestionsMedia).toEqual(mockSectionQuestions[0].media);
+    expect(component.setImageZoom).toHaveBeenCalled();
+  }));
+
+  it('should fetch when jumping to a not-yet-loaded question', fakeAsync(() => {
+    component.myCarousel = jasmine.createSpyObj("CarouselComponent", { selectSlide: {}, getCurrentSlideIndex: 1 });
+    component.questions = [];
+    spyOn(viewerService, 'getQuestions');
+    spyOn(component, 'setImageZoom');
+    spyOn(component, 'highlightQuestion');
+    component.goToQuestion({ questionNo: 1 });
+    tick();
+    expect(viewerService.getQuestions).toHaveBeenCalledWith(0, 1);
+    expect(component.myCarousel.selectSlide).not.toHaveBeenCalled();
+  }));
+
   it('should navigate to previous slide', () => {
     spyOn(viewerService, 'raiseHeartBeatEvent');
     spyOn(component, 'setImageZoom');

--- a/projects/quml-library/src/lib/section-player/section-player.component.ts
+++ b/projects/quml-library/src/lib/section-player/section-player.component.ts
@@ -937,9 +937,22 @@ export class SectionPlayerComponent implements OnChanges, AfterViewInit {
     this.disableNext = false;
     this.initializeTimer = true;
     const index = event.questionNo;
-    this.viewerService.getQuestions(0, index);
     this.currentSlideIndex = index;
-    this.myCarousel.selectSlide(index);
+    // Only fetch when the target question isn't already loaded. Calling
+    // getQuestions() unconditionally re-splices identifiers and re-emits the
+    // question event, which rebuilds the questions array and desyncs the
+    // carousel — the jumped-to question briefly renders twice. Mirrors goToSlide.
+    if (this.questions[index - 1] === undefined) {
+      this.showQuestions = false;
+      this.viewerService.getQuestions(0, index);
+    } else {
+      this.myCarousel.selectSlide(index);
+    }
+    // Mirror goToSlide/nextSlide: without setting the slide media and re-running
+    // setImageZoom(), the jumped-to (first reviewed) question keeps its relative
+    // <img src> and the image 404s until the learner navigates to the next slide.
+    this.currentQuestionsMedia = _.get(this.questions[this.currentSlideIndex - 1], 'media');
+    setTimeout(() => { this.setImageZoom(); });
     this.highlightQuestion();
   }
 

--- a/projects/quml-library/src/lib/section-player/section-player.component.ts
+++ b/projects/quml-library/src/lib/section-player/section-player.component.ts
@@ -943,15 +943,20 @@ export class SectionPlayerComponent implements OnChanges, AfterViewInit {
     // question event, which rebuilds the questions array and desyncs the
     // carousel — the jumped-to question briefly renders twice. Mirrors goToSlide.
     if (this.questions[index - 1] === undefined) {
+      // Not loaded yet: fetch. The qumlQuestionEvent subscription selects the
+      // slide, sets media, and runs setImageZoom()/highlightQuestion() once the
+      // questions arrive and the DOM has updated — doing it here would run
+      // against the previous slide's DOM (duplicate magnify icons / wrong srcs).
       this.showQuestions = false;
       this.viewerService.getQuestions(0, index);
-    } else {
-      this.myCarousel.selectSlide(index);
+      return;
     }
-    // Mirror goToSlide/nextSlide: without setting the slide media and re-running
-    // setImageZoom(), the jumped-to (first reviewed) question keeps its relative
-    // <img src> and the image 404s until the learner navigates to the next slide.
-    this.currentQuestionsMedia = _.get(this.questions[this.currentSlideIndex - 1], 'media');
+    // Already loaded (review): no fetch will fire, so set the slide media and
+    // re-run setImageZoom() here. Otherwise the jumped-to (first reviewed)
+    // question keeps its relative <img src> and the image 404s until the learner
+    // navigates to the next slide. Mirrors goToSlide/nextSlide.
+    this.myCarousel.selectSlide(index);
+    this.currentQuestionsMedia = _.get(this.questions[index - 1], 'media');
     setTimeout(() => { this.setImageZoom(); });
     this.highlightQuestion();
   }

--- a/projects/quml-library/src/lib/util-service.ts
+++ b/projects/quml-library/src/lib/util-service.ts
@@ -111,7 +111,7 @@ export class UtilService {
             // Skip srcs already absolutised (e.g. by the solution panel's
             // bind-time resolver); re-prefixing baseUrl would yield a broken
             // "https://...https://..." URL and the video would not play.
-            const isAbsolute = (s: string) => /^https?:\/\//i.test(s ?? '');
+            const isAbsolute = (s?: string | null) => /^https?:\/\//i.test(s ?? '');
 
             if(!_.isEmpty(asset) && posterSrc && !isAbsolute(posterSrc)) {
                 element['poster'] = baseUrl ? `${baseUrl}/${identifier}/${posterSrc}` : asset[0].baseUrl + posterSrc;
@@ -121,7 +121,7 @@ export class UtilService {
                 const sourceElement = Array.from(element.getElementsByTagName('source') as HTMLCollectionOf<Element>);
                 _.forEach(sourceElement, (element: HTMLElement) => {
                     const sourceSrc = element.getAttribute('src');
-                    if (isAbsolute(sourceSrc)) { return; }
+                    if (!sourceSrc || isAbsolute(sourceSrc)) { return; }
                     element['src'] = baseUrl ? `${baseUrl}/${identifier}/${sourceSrc}` : asset[0].baseUrl + sourceSrc;
                 });
             }

--- a/web-component/package.json
+++ b/web-component/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-sunbird/sunbird-quml-player-web-component",
-    "version": "6.0.9",
+    "version": "6.0.10",
     "description": "The web component package for the sunbird QuML player",
     "main": "assets/quml-player/sunbird-quml-player.js",
     "scripts": {


### PR DESCRIPTION
## Summary

  Fixes image-loading and layout issues for question solutions and the Sequence (SEQ) question type, surfaced
  while testing package `6.0.9` on the portal and mobile.

  The core bug: when a learner finishes a question set, clicks **Review**, and lands on the **first** question,
  its images failed to load (and the question briefly rendered twice). Images only resolved from the *second*
  question onward. This was a gap in the Review-jump navigation path (`goToQuestion`) compared to every other
  navigation method.

  ## Changes

  ### 1. Review-jump image loading & double-render (`section-player.component.ts`)
  `goToQuestion()` (the Review/scoreboard jump handler) differed from `nextSlide`/`prevSlide`/`goToSlide`:
  - It called `viewerService.getQuestions()` **unconditionally** — even when the target question was already
  loaded. That re-splices identifiers and re-emits `qumlQuestionEvent`, rebuilding the `questions` array and
  desyncing the carousel, so the jumped-to question briefly rendered twice.
  - It never set `currentQuestionsMedia` nor ran `setImageZoom()`, so the first reviewed question kept its
  relative `<img src>` (e.g. `/assets/public/content/...`) and 404'd until the learner navigated forward.

  Fix — mirror the already-correct `goToSlide()`:
  - **Already-loaded (review) path** → `selectSlide` + set media + `setImageZoom()` + `highlightQuestion()`.
  - **Not-yet-loaded path** → fetch and `return` early; the `qumlQuestionEvent` subscription already selects the
  slide, sets media, and runs `setImageZoom()`/`highlightQuestion()` once data arrives and the DOM updates (avoids
  duplicate magnify icons / wrong srcs).

  ### 2. Sequence (SEQ) item image sizing (`ordered.component.scss`)
  SEQ card images (`.card-label`, rendered via `innerHTML`) had no size cap — only the question body did. A wide
  image rendered at natural size and dominated the row while others stayed small. Added a uniform `max-height:
  6rem` / `object-fit: contain` cap so all items line up. Covers all three SEQ layouts (vertical, horizontal,
  grid) since they share `.card-label`.

  ### 3. Video source resolution hardening (`util-service.ts`)
  Addressed Copilot review feedback on `updateSourceOfVideoElement`:
  - `isAbsolute` now accepts `string | null` (compiles cleanly under `strictNullChecks`).
  - Guards a missing `<source src>` (`if (!sourceSrc || isAbsolute(sourceSrc)) return;`) so a malformed element no
  longer builds a `.../null` URL.

  ## Why it wasn't caught locally
  Local dev proxies relative `/assets/...` requests to the content host, so the un-rewritten relative `src` loaded
  anyway, masking both the missing-image and double-render symptoms. They only surfaced in the published package
  where there is no proxy.

  ## Tests
  - Added/updated specs in `section-player.component.spec.ts`:
    - Review jump to an already-loaded question → selects slide, sets media, runs `setImageZoom()`.
    - Jump to a not-yet-loaded question → fetches and defers slide/zoom/highlight to the subscription (asserts
  they are **not** called directly).
  - Full quml-library suite green (`section-player` 103/103; `ordered` + `util-service` 42/42).

  ## Testing notes / caveats
  - Verified on the portal via the web-component bundle (Review → first question now loads images once; SEQ items
  uniform).
  - **Not-yet-loaded path** → fetch and `return` early; the `qumlQuestionEvent` subscription already selects the
  slide, sets media, and runs `setImageZoom()`/`highlightQuestion()` once data arrives and the DOM updates (avoids
  duplicate magnify icons / wrong srcs).

  ### 2. Sequence (SEQ) item image sizing (`ordered.component.scss`)
  SEQ card images (`.card-label`, rendered via `innerHTML`) had no size cap — only the question body did. A wide
  image rendered at natural size and dominated the row while others stayed small. Added a uniform `max-height:
  6rem` / `object-fit: contain` cap so all items line up. Covers all three SEQ layouts (vertical, horizontal,
  grid) since they share `.card-label`.

  ### 3. Video source resolution hardening (`util-service.ts`)
  Addressed Copilot review feedback on `updateSourceOfVideoElement`:
  - `isAbsolute` now accepts `string | null` (compiles cleanly under `strictNullChecks`).
  - Guards a missing `<source src>` (`if (!sourceSrc || isAbsolute(sourceSrc)) return;`) so a malformed element no
  longer builds a `.../null` URL.

  ## Why it wasn't caught locally
  Local dev proxies relative `/assets/...` requests to the content host, so the un-rewritten relative `src` loaded
  anyway, masking both the missing-image and double-render symptoms. They only surfaced in the published package
  where there is no proxy.

  ## Tests
  - Added/updated specs in `section-player.component.spec.ts`:
    - Review jump to an already-loaded question → selects slide, sets media, runs `setImageZoom()`.
    - Jump to a not-yet-loaded question → fetches and defers slide/zoom/highlight to the subscription (asserts
  they are **not** called directly).
  - Full quml-library suite green (`section-player` 103/103; `ordered` + `util-service` 42/42).

  ## Testing notes / caveats
  - Verified on the portal via the web-component bundle (Review → first question now loads images once; SEQ items
  uniform).
  - **Mobile offline** (`isAvailableLocally`): changes are additive and preserve the existing offline branch in
  `setImageZoom()`, but this was **not** device-verified. Recommend a download-and-review pass on the device build
  before release.

  ## Files changed
  - `projects/quml-library/src/lib/section-player/section-player.component.ts`
  - `projects/quml-library/src/lib/section-player/section-player.component.spec.ts`
  - `projects/quml-library/src/lib/ordered/ordered.component.scss`
  - `projects/quml-library/src/lib/util-service.ts`