### PR TITLE
fix(react): define process.env.NODE_ENV in the web-component build (0…

### DIFF
--- a/projects/sunbird-quml-player-react/package-lock.json
+++ b/projects/sunbird-quml-player-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@project-sunbird/client-services": "^8.1.4",
         "@project-sunbird/sb-styles": "0.0.16",

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/vite.config.ts
+++ b/projects/sunbird-quml-player-react/vite.config.ts
@@ -24,6 +24,15 @@ export default defineConfig(({ command }) => {
       },
     },
 
+    // The IIFE web-component bundle runs in the browser, which has no `process`.
+    // React and other deps branch on `process.env.NODE_ENV`; Vite does NOT inline
+    // it in library mode, so without this the bundle throws "process is not
+    // defined" at load. Inline it to the production string — but ONLY for the
+    // build; in dev, Vite manages NODE_ENV (development) for HMR/React dev mode.
+    define: isBuild
+      ? { 'process.env.NODE_ENV': JSON.stringify('production') }
+      : {},
+
     // ── Development mode (vite / npm run dev) ──────────────────────────────
     server: {
       port: 3000,


### PR DESCRIPTION
….1.1)

The IIFE web-component bundle runs in the browser (no `process`), but Vite does not inline process.env.NODE_ENV in library mode, so React's `process.env.NODE_ENV` checks left bare `process` refs → "ReferenceError: process is not defined" at load (surfaced on editor preview). Add a build-only `define` inlining it to 'production'; dev is untouched so HMR/React dev mode still work.

Verified: rebuilt bundle has 0 unguarded process refs (1 remaining is typeof- guarded); loading it in a Node-global-free jsdom context registers and mounts <sunbird-quml-player> with no ReferenceError. Bump to 0.1.1 for republish.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules