### PR TITLE
fix(react): accept questionset from playerConfig.metadata, not just d…

### DIFF
--- a/projects/sunbird-quml-player-react/package-lock.json
+++ b/projects/sunbird-quml-player-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dependencies": {
         "@project-sunbird/client-services": "^8.1.4",
         "@project-sunbird/sb-styles": "0.0.16",

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.metadata-config.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.metadata-config.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import type { PlayerConfig } from '../../types';
+
+// The Sunbird editor/portal pass the questionset under `playerConfig.metadata`
+// (Angular contract) with `data` empty. Mock the data service to assert the
+// player fetches using the identifier taken from metadata.
+const { loadQuestionSet } = vi.hoisted(() => ({ loadQuestionSet: vi.fn() }));
+vi.mock('../../services/data-service', () => ({ loadQuestionSet }));
+
+describe('MainPlayer — metadata config contract (editor/portal)', () => {
+  it('fetches by identifier from playerConfig.metadata when data is empty', async () => {
+    loadQuestionSet.mockResolvedValue({
+      metadata: { name: 'questionset-t1' },
+      sections: [],
+    });
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: { identifier: 'do_qs1', name: 'questionset-t1' },
+      data: {},
+    };
+
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+
+    await waitFor(() =>
+      expect(loadQuestionSet).toHaveBeenCalledWith('do_qs1', expect.anything()),
+    );
+    // The overview title reflects the fetched metadata name, not the fallback.
+    await waitFor(() => expect(screen.getByText('questionset-t1')).toBeInTheDocument());
+  });
+
+  it('does not fetch when neither data nor metadata carries an identifier', async () => {
+    loadQuestionSet.mockClear();
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: {},
+      data: {},
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+    // Give effects a tick; loadQuestionSet must not be called.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(loadQuestionSet).not.toHaveBeenCalled();
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.metadata-config.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.metadata-config.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import { QumlProvider } from '../../context/QumlContext';
 import { MainPlayer } from './MainPlayer';
 import type { PlayerConfig } from '../../types';
@@ -49,8 +49,26 @@ describe('MainPlayer — metadata config contract (editor/portal)', () => {
         <MainPlayer playerConfig={cfg} />
       </QumlProvider>,
     );
-    // Give effects a tick; loadQuestionSet must not be called.
-    await new Promise((r) => setTimeout(r, 50));
+    // Flush effects with a single microtask tick; the no-identifier path returns
+    // synchronously, so loadQuestionSet must not be called.
+    await act(async () => {});
+    expect(loadQuestionSet).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when the identifier is a non-string (guards against .../[object Object])', async () => {
+    loadQuestionSet.mockClear();
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: { identifier: { bad: true } as unknown as string },
+      data: {},
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+    await act(async () => {});
     expect(loadQuestionSet).not.toHaveBeenCalled();
   });
 });

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -91,7 +91,11 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setPlayerConfig(playerConfig);
 
     const data = (playerConfig.data as Record<string, unknown> | undefined) ?? {};
-    const rawSections = (data.sections as unknown[] | undefined) ?? [];
+    // Host-contract compatibility: the Sunbird editor/portal follow the Angular
+    // contract — they pass the questionset under `playerConfig.metadata` and leave
+    // `data` empty. Fall back to metadata so both config shapes load.
+    const meta = (playerConfig.metadata as Record<string, unknown> | undefined) ?? {};
+    const rawSections = ((data.sections ?? meta.sections) as unknown[] | undefined) ?? [];
 
     // EMBEDDED path (unchanged behavior).
     if (rawSections.length > 0) {
@@ -105,13 +109,14 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
           return { ...normalized, children };
         })
         .filter((s): s is Section => Boolean(s));
-      setMetadata(data);
+      // Overview metadata comes from whichever source carried the sections.
+      setMetadata(data.sections ? data : meta);
       setSections(sections);
       return;
     }
 
     // FETCHED path — delegate ALL network + normalization to the data service.
-    const identifier = data.identifier as string | undefined;
+    const identifier = (data.identifier ?? meta.identifier) as string | undefined;
     if (!identifier) return;
     // API base URL only — the content/asset base (config.baseUrl) is separate and
     // used for image resolution, so it must NOT leak into API requests.

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -95,7 +95,10 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     // contract — they pass the questionset under `playerConfig.metadata` and leave
     // `data` empty. Fall back to metadata so both config shapes load.
     const meta = (playerConfig.metadata as Record<string, unknown> | undefined) ?? {};
-    const rawSections = ((data.sections ?? meta.sections) as unknown[] | undefined) ?? [];
+    // Guard with Array.isArray: a non-array `sections` (e.g. a string) would have
+    // a truthy `.length` and crash on `.map` in the embedded path below.
+    const sectionsCandidate = data.sections ?? meta.sections;
+    const rawSections = Array.isArray(sectionsCandidate) ? (sectionsCandidate as unknown[]) : [];
 
     // EMBEDDED path (unchanged behavior).
     if (rawSections.length > 0) {
@@ -116,7 +119,10 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     }
 
     // FETCHED path — delegate ALL network + normalization to the data service.
-    const identifier = (data.identifier ?? meta.identifier) as string | undefined;
+    // Require a real string id: a non-string (e.g. an object) would otherwise
+    // build a bad request URL like `.../[object Object]`.
+    const identifierCandidate = data.identifier ?? meta.identifier;
+    const identifier = typeof identifierCandidate === 'string' ? identifierCandidate : undefined;
     if (!identifier) return;
     // API base URL only — the content/asset base (config.baseUrl) is separate and
     // used for image resolution, so it must NOT leak into API requests.

--- a/projects/sunbird-quml-player-react/src/services/data-service.realpayload.test.ts
+++ b/projects/sunbird-quml-player-react/src/services/data-service.realpayload.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./http-client', () => ({ httpGet: vi.fn(), httpPost: vi.fn() }));
+import { httpGet, httpPost } from './http-client';
+import { loadQuestionSet } from './data-service';
+
+const mockGet = httpGet as unknown as ReturnType<typeof vi.fn>;
+const mockPost = httpPost as unknown as ReturnType<typeof vi.fn>;
+
+// Real payloads (trimmed) from the failing editor preview, questionset
+// do_21460978863471001611 → Section-1 (objectType QuestionSet) → mcq question.
+const hierarchy = {
+  questionset: {
+    identifier: 'do_21460978863471001611',
+    name: 'questionset-t1',
+    objectType: 'QuestionSet',
+    children: [
+      {
+        identifier: 'do_214609803662934016110',
+        name: 'Section-1',
+        objectType: 'QuestionSet',
+        primaryCategory: 'Practice Question Set',
+        allowSkip: 'Yes',
+        showFeedback: true,
+        children: [
+          {
+            identifier: 'do_214609803972239360113',
+            objectType: 'Question',
+            primaryCategory: 'Multiple Choice Question',
+            qType: 'MCQ',
+            index: 1,
+          },
+        ],
+      },
+    ],
+  },
+};
+
+const questions = [
+  {
+    identifier: 'do_214609803972239360113',
+    qType: 'MCQ',
+    primaryCategory: 'Multiple Choice Question',
+    body: '<div class="mcq-title">smallest planet in solar system</div>',
+    interactions: {
+      response1: {
+        type: 'choice',
+        options: [
+          { label: { en: 'Mercury' }, value: 0 },
+          { label: { en: 'venus' }, value: 1 },
+        ],
+      },
+    },
+    responseDeclaration: {
+      response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 0 } },
+    },
+    maxScore: 1,
+  },
+];
+
+describe('loadQuestionSet — real editor-preview payload', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+  });
+
+  it('merges hierarchy + list into a section with the question (not 0)', async () => {
+    mockGet.mockResolvedValue({ questionset: hierarchy.questionset });
+    mockPost.mockResolvedValue({ questions });
+
+    const { sections } = await loadQuestionSet('do_21460978863471001611');
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].children).toHaveLength(1); // ← the bug was 0
+    const q = sections[0].children[0];
+    expect(q.identifier).toBe('do_214609803972239360113');
+    expect(q.body).toContain('smallest planet'); // fetched content merged in
+    expect(q.qType).toBe('MCQ');
+  });
+});


### PR DESCRIPTION
…ata (0.1.2)

The Sunbird editor/portal follow the Angular contract — they pass the questionset under playerConfig.metadata and leave data empty. initializeFromConfig read the identifier/sections ONLY from playerConfig.data, so with data:{} it returned early → no sections → SectionPlayer showed "Error loading content" and the overview title fell back to "Assessment Overview".

Fall back to playerConfig.metadata for both the fetched identifier and embedded sections; overview metadata is taken from whichever source carried the sections.

Verified with the real editor-preview payloads: MainPlayer fetches by metadata.identifier (metadata-config test); loadQuestionSet merges the actual hierarchy + list responses into a section containing the question (realpayload test, was 0). Bump to 0.1.2.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules