### PR TITLE
fix(react): render embedded questionset + host-configurable fetch end…

### DIFF
--- a/projects/sunbird-quml-player-react/package-lock.json
+++ b/projects/sunbird-quml-player-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "dependencies": {
         "@project-sunbird/client-services": "^8.1.4",
         "@project-sunbird/sb-styles": "0.0.16",

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.embedded-render.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.embedded-render.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import type { PlayerConfig } from '../../types';
+
+// The real editor/portal contract: the WHOLE questionset with question content
+// embedded in metadata.children (Section A: MCQ + SA; Section B: FTB + REO).
+// This drives the full render path (no network) to prove questions actually paint.
+const metadata = {
+  identifier: 'do_214609811633471488164',
+  name: 'Sample question set',
+  objectType: 'QuestionSetImage',
+  timeLimits: { questionSet: { max: 0, min: 0 } },
+  children: [
+    {
+      identifier: 'do_secA',
+      name: 'Section A',
+      objectType: 'QuestionSet',
+      index: 1,
+      children: [
+        {
+          identifier: 'do_q1',
+          name: 'Q1',
+          objectType: 'Question',
+          primaryCategory: 'Multiple Choice Question',
+          qType: 'MCQ',
+          index: 1,
+          maxScore: 5,
+          body: '<div class="mcq-title">Which is the capital of France?</div>',
+          interactions: {
+            response1: {
+              type: 'choice',
+              options: [
+                { label: { en: 'New York' }, value: 0 },
+                { label: { en: 'Paris' }, value: 1 },
+              ],
+            },
+          },
+          responseDeclaration: {
+            response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 1 } },
+          },
+        },
+        {
+          identifier: 'do_q2',
+          name: 'Q2',
+          objectType: 'Question',
+          primaryCategory: 'Subjective Question',
+          qType: 'SA',
+          index: 2,
+          maxScore: 5,
+          body: 'When is Independence Day observed in India',
+          interactions: {},
+          answer: '<div class="answer-body">15th August</div>',
+        },
+      ],
+    },
+    {
+      identifier: 'do_secB',
+      name: 'Section B',
+      objectType: 'QuestionSet',
+      index: 2,
+      children: [
+        {
+          identifier: 'do_q3',
+          name: 'Q3',
+          objectType: 'Question',
+          primaryCategory: 'FTB Question',
+          qType: 'FTB',
+          index: 1,
+          maxScore: 1,
+          body: 'The tree is [[response1]]',
+          interactions: { response1: { type: 'text' } },
+          responseProcessing: { template: 'MAP_RESPONSE' },
+          responseDeclaration: {
+            response1: {
+              cardinality: 'single',
+              type: 'string',
+              correctResponse: { value: 'tall' },
+              mapping: [{ value: 'tall', score: 1, caseSensitive: false }],
+            },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const cfg: PlayerConfig = { context: {}, config: { language: 'en' }, metadata, data: {} };
+
+const renderPlayer = () =>
+  render(
+    <QumlProvider playerConfig={cfg}>
+      <MainPlayer playerConfig={cfg} />
+    </QumlProvider>,
+  );
+
+describe('MainPlayer — renders from embedded metadata (portal/editor contract)', () => {
+  it('shows the real assessment name on the overview (not the fallback)', () => {
+    renderPlayer();
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+    // Real name proves metadata was consumed (fallback would be "Assessment Overview").
+    expect(screen.getByText('Sample question set')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /start assessment/i })).toBeInTheDocument();
+  });
+
+  it('paints the first question stem + options after entering the assessment', () => {
+    renderPlayer();
+    fireEvent.click(screen.getByRole('button', { name: /start assessment/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start section/i }));
+    // The MCQ stem and both option labels actually reach the DOM.
+    expect(screen.getByText(/capital of France/i)).toBeInTheDocument();
+    expect(screen.getByText('Paris')).toBeInTheDocument();
+    expect(screen.getByText('New York')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.metadata-config.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.metadata-config.test.tsx
@@ -8,7 +8,12 @@ import type { PlayerConfig } from '../../types';
 // (Angular contract) with `data` empty. Mock the data service to assert the
 // player fetches using the identifier taken from metadata.
 const { loadQuestionSet } = vi.hoisted(() => ({ loadQuestionSet: vi.fn() }));
-vi.mock('../../services/data-service', () => ({ loadQuestionSet }));
+// These configs carry no embedded question content, so force the fetch path.
+vi.mock('../../services/data-service', () => ({
+  loadQuestionSet,
+  hasEmbeddedQuestions: () => false,
+  transformEmbeddedQuestionSet: () => [],
+}));
 
 describe('MainPlayer — metadata config contract (editor/portal)', () => {
   it('fetches by identifier from playerConfig.metadata when data is empty', async () => {

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.portal-fetch.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.portal-fetch.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import type { PlayerConfig } from '../../types';
+
+// Simulate the PORTAL end-to-end: it passes SHALLOW metadata (identifier only,
+// from /content/v1/read) and sets the /portal gateway URLs. The player must
+// fetch hierarchy (stubs) + list (bodies) from those URLs, merge, and render.
+vi.mock('../../services/http-client', () => ({ httpGet: vi.fn(), httpPost: vi.fn() }));
+import { httpGet, httpPost } from '../../services/http-client';
+const mockGet = httpGet as unknown as ReturnType<typeof vi.fn>;
+const mockPost = httpPost as unknown as ReturnType<typeof vi.fn>;
+
+// /portal/questionset/v2/hierarchy → sections with STUB questions (no body).
+const hierarchy = {
+  questionset: {
+    identifier: 'do_qs',
+    name: 'Sample question set',
+    objectType: 'QuestionSetImage',
+    children: [
+      {
+        identifier: 'do_secA',
+        name: 'Section A',
+        objectType: 'QuestionSet',
+        index: 1,
+        children: [
+          { identifier: 'do_q1', objectType: 'Question', qType: 'MCQ', primaryCategory: 'Multiple Choice Question', index: 1 },
+        ],
+      },
+    ],
+  },
+};
+
+// /portal/question/v2/list → full question content (bodies + interactions).
+const questions = [
+  {
+    identifier: 'do_q1',
+    qType: 'MCQ',
+    primaryCategory: 'Multiple Choice Question',
+    maxScore: 5,
+    body: '<div class="mcq-title">Which is the capital of France?</div>',
+    interactions: {
+      response1: {
+        type: 'choice',
+        options: [
+          { label: { en: 'New York' }, value: 0 },
+          { label: { en: 'Paris' }, value: 1 },
+        ],
+      },
+    },
+    responseDeclaration: {
+      response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 1 } },
+    },
+  },
+];
+
+// Shallow metadata, exactly like the portal's content-read result.
+const cfg: PlayerConfig = {
+  context: {},
+  config: { language: 'en' },
+  metadata: { identifier: 'do_qs', name: 'Sample question set' },
+  data: {},
+};
+
+describe('MainPlayer — full portal path (shallow metadata → /portal fetch → render)', () => {
+  beforeEach(() => {
+    mockGet.mockReset();
+    mockPost.mockReset();
+    (window as any).questionSetHierarchyUrl = '/portal/questionset/v2/hierarchy/';
+    (window as any).questionListUrl = '/portal/question/v2/list';
+  });
+  afterEach(() => {
+    delete (window as any).questionSetHierarchyUrl;
+    delete (window as any).questionListUrl;
+  });
+
+  it('fetches from the /portal gateway URLs, merges, and renders the question', async () => {
+    mockGet.mockResolvedValue(hierarchy);
+    mockPost.mockResolvedValue({ questions });
+
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+
+    // Hierarchy fetched from the portal gateway route (not /learner).
+    await waitFor(() =>
+      expect(mockGet).toHaveBeenCalledWith('/portal/questionset/v2/hierarchy/do_qs', expect.anything()),
+    );
+    // Question list fetched from the portal gateway route (not /api or /action);
+    // a ?lang= suffix is appended from config.language.
+    expect(mockPost.mock.calls[0][0]).toContain('/portal/question/v2/list');
+
+    // Overview shows, then enter the assessment and confirm the question paints.
+    await waitFor(() => expect(screen.getByText('Sample question set')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: /start assessment/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start section/i }));
+    expect(screen.getByText(/capital of France/i)).toBeInTheDocument();
+    expect(screen.getByText('Paris')).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -14,7 +14,11 @@ import { ResultsScreen } from '../ResultsScreen/ResultsScreen';
 import { ReviewScreen } from '../ReviewScreen/ReviewScreen';
 import { t, readI18n } from '../../i18n/translations';
 import { transformSection, transformQuestion } from '../../services/transformation-service';
-import { loadQuestionSet } from '../../services/data-service';
+import {
+  loadQuestionSet,
+  hasEmbeddedQuestions,
+  transformEmbeddedQuestionSet,
+} from '../../services/data-service';
 import { QumlApiError } from '../../types/api';
 import { calculateScore } from '../../registry/scoring-registry';
 import { isAnswered } from '../../utils/answered';
@@ -116,6 +120,19 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
       setMetadata(data.sections ? data : meta);
       setSections(sections);
       return;
+    }
+
+    // EMBEDDED-METADATA path: hosts (Sunbird editor/portal) pass the WHOLE
+    // questionset — with question content embedded in its hierarchy — as
+    // `metadata`. Render it directly, no network calls. This also avoids relying
+    // on the player's own API endpoints matching the host's proxy routing.
+    if (hasEmbeddedQuestions(meta)) {
+      const sections = transformEmbeddedQuestionSet(meta);
+      if (sections.length > 0) {
+        setMetadata(meta);
+        setSections(sections);
+        return;
+      }
     }
 
     // FETCHED path — delegate ALL network + normalization to the data service.

--- a/projects/sunbird-quml-player-react/src/services/data-service.embedded.test.ts
+++ b/projects/sunbird-quml-player-react/src/services/data-service.embedded.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { hasEmbeddedQuestions, transformEmbeddedQuestionSet } from './data-service';
+
+// Real metadata (trimmed) the editor/portal pass as playerConfig.metadata:
+// the WHOLE questionset with question content embedded in the hierarchy —
+// Section A [Q1 MCQ, Q2 SA], Section B [Q3 FTB, Q5 REO].
+const metadata = {
+  identifier: 'do_214609811633471488164',
+  name: 'Sample question set',
+  objectType: 'QuestionSetImage',
+  timeLimits: { questionSet: { max: 0, min: 0 } },
+  children: [
+    {
+      identifier: 'do_214609815842570240180',
+      name: 'Section A',
+      objectType: 'QuestionSet',
+      index: 1,
+      children: [
+        {
+          identifier: 'do_214609815842586624182',
+          name: 'Q1',
+          objectType: 'Question',
+          primaryCategory: 'Multiple Choice Question',
+          qType: 'MCQ',
+          index: 1,
+          maxScore: 5,
+          body: '<div class="mcq-title">Which is the capital of France?</div>',
+          interactions: {
+            response1: {
+              type: 'choice',
+              options: [
+                { label: { en: 'New York' }, value: 0 },
+                { label: { en: 'Paris' }, value: 1 },
+              ],
+            },
+          },
+          responseDeclaration: {
+            response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 1 } },
+          },
+        },
+        {
+          identifier: 'do_2146098163851018241112',
+          name: 'Q2',
+          objectType: 'Question',
+          primaryCategory: 'Subjective Question',
+          qType: 'SA',
+          index: 2,
+          maxScore: 5,
+          body: 'When is Independence Day observed in India',
+          interactions: {},
+          answer: '<div class="answer-body">15th August</div>',
+        },
+      ],
+    },
+    {
+      identifier: 'do_21460983368164147213',
+      name: 'Section B',
+      objectType: 'QuestionSet',
+      index: 2,
+      children: [
+        {
+          identifier: 'do_21460983367935590411',
+          name: 'Q3',
+          objectType: 'Question',
+          primaryCategory: 'FTB Question',
+          qType: 'FTB',
+          index: 1,
+          maxScore: 1,
+          body: 'The tree is [[response1]]',
+          interactions: { response1: { type: 'text' } },
+          responseProcessing: { template: 'MAP_RESPONSE' },
+          evalUnordered: true,
+          responseDeclaration: {
+            response1: {
+              cardinality: 'single',
+              type: 'string',
+              correctResponse: { value: 'tall' },
+              mapping: [{ value: 'tall', score: 1, caseSensitive: false }],
+            },
+          },
+        },
+        {
+          identifier: 'do_21460983413725593617',
+          name: 'Q5',
+          objectType: 'Question',
+          primaryCategory: 'Reorder Question',
+          qType: 'REO',
+          index: 2,
+          maxScore: 1,
+          body: '<div class="order-title">Reorder the sentence</div>',
+          interactions: {
+            response1: {
+              type: 'order',
+              options: [
+                { value: 'A', label: 'Book' },
+                { value: 'B', label: 'is' },
+              ],
+            },
+          },
+          responseProcessing: { template: 'MATCH_CORRECT' },
+        },
+      ],
+    },
+  ],
+};
+
+describe('embedded questionset metadata (editor/portal contract)', () => {
+  it('detects embedded question content', () => {
+    expect(hasEmbeddedQuestions(metadata)).toBe(true);
+  });
+
+  it('does NOT flag a stub-only hierarchy as embedded', () => {
+    const stubHierarchy = {
+      identifier: 'do_x',
+      children: [
+        {
+          identifier: 'sec',
+          objectType: 'QuestionSet',
+          children: [{ identifier: 'q', objectType: 'Question', qType: 'MCQ' }], // no body/interactions
+        },
+      ],
+    };
+    expect(hasEmbeddedQuestions(stubHierarchy)).toBe(false);
+  });
+
+  it('builds 2 sections with the 4 embedded questions (no fetch)', () => {
+    const sections = transformEmbeddedQuestionSet(metadata);
+    expect(sections).toHaveLength(2);
+    expect(sections[0].children.map((q) => q.qType)).toEqual(['MCQ', 'SA']);
+    expect(sections[1].children.map((q) => q.qType)).toEqual(['FTB', 'REO']);
+    // content survived the transform
+    expect(sections[0].children[0].body).toContain('capital of France');
+    expect(sections[1].children[0].body).toContain('[[response1]]');
+    // scoring hints preserved for FTB
+    expect(sections[1].children[0].responseProcessing?.template).toBe('MAP_RESPONSE');
+    expect(sections[1].children[0].evalUnordered).toBe(true);
+  });
+});

--- a/projects/sunbird-quml-player-react/src/services/data-service.test.ts
+++ b/projects/sunbird-quml-player-react/src/services/data-service.test.ts
@@ -87,6 +87,16 @@ describe('data-service', () => {
       expect(mockGet).not.toHaveBeenCalled();
     });
 
+    it('honors a host-provided window.questionSetHierarchyUrl override', async () => {
+      (window as any).questionSetHierarchyUrl = '/action/questionset/v2/hierarchy/';
+      mockGet.mockResolvedValue({ questionset: hierarchy.questionset });
+      await getQuestionSetHierarchy('do_set');
+      expect(mockGet).toHaveBeenCalledWith('/action/questionset/v2/hierarchy/do_set', {
+        baseURL: undefined,
+      });
+      delete (window as any).questionSetHierarchyUrl;
+    });
+
     it('throws invalid when questionset is missing', async () => {
       mockGet.mockResolvedValue({});
       await expect(getQuestionSetHierarchy('do_set')).rejects.toMatchObject({ kind: 'invalid' });
@@ -109,6 +119,18 @@ describe('data-service', () => {
         { request: { search: { identifier: ['q1', 'q2'] } } },
         { baseURL: 'https://host' },
       );
+    });
+
+    it('honors a host-provided window.questionListUrl override', async () => {
+      (window as any).questionListUrl = '/action/question/v2/list';
+      mockPost.mockResolvedValue({ questions });
+      await getQuestions(['q1']);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/action/question/v2/list',
+        { request: { search: { identifier: ['q1'] } } },
+        { baseURL: undefined },
+      );
+      delete (window as any).questionListUrl;
     });
 
     it('chunks large id lists into batches of 50 and concatenates results', async () => {

--- a/projects/sunbird-quml-player-react/src/services/data-service.ts
+++ b/projects/sunbird-quml-player-react/src/services/data-service.ts
@@ -40,6 +40,19 @@ export interface LoadedQuestionSet {
   sections: Section[];
 }
 
+/**
+ * Host-provided endpoint override (the Sunbird QuestionCursor equivalent).
+ * The player's default API paths don't match every host's proxy routing (e.g.
+ * the portal serves the question list under `/action/…`, not `/api/…`, and does
+ * not proxy `/learner/…`). A host can set `window.questionListUrl` /
+ * `window.questionSetHierarchyUrl` to point the fetch at the right route; we fall
+ * back to the built-in defaults (which the editor's dev proxy serves) otherwise.
+ */
+function hostEndpoint(key: 'questionListUrl' | 'questionSetHierarchyUrl'): string | undefined {
+  const val = typeof window !== 'undefined' ? (window as unknown as Record<string, unknown>)[key] : undefined;
+  return typeof val === 'string' && val ? val : undefined;
+}
+
 /** Fetch the raw questionset hierarchy (`result.questionset`). */
 export async function getQuestionSetHierarchy(
   identifier: string,
@@ -48,7 +61,9 @@ export async function getQuestionSetHierarchy(
   if (!identifier) {
     throw new QumlApiError('invalid', 'getQuestionSetHierarchy: identifier is required');
   }
-  const url = `${ApiEndPoints.getQuestionSetHierarchy}${identifier}`;
+  const base = hostEndpoint('questionSetHierarchyUrl') ?? ApiEndPoints.getQuestionSetHierarchy;
+  // Base ends with `/` (identifier appended); tolerate a host value without one.
+  const url = base.endsWith('/') ? `${base}${identifier}` : `${base}/${identifier}`;
   const result = await httpGet<QuestionSetHierarchyResult>(url, { baseURL: opts.baseUrl });
   if (!result?.questionset) {
     throw new QumlApiError('invalid', 'Hierarchy response missing `questionset`');
@@ -69,9 +84,8 @@ export async function getQuestions(
   opts: LoadOptions = {},
 ): Promise<RawQuestion[]> {
   if (!identifiers || identifiers.length === 0) return [];
-  const url = opts.language
-    ? `${ApiEndPoints.questionList}?lang=${opts.language}`
-    : ApiEndPoints.questionList;
+  const listBase = hostEndpoint('questionListUrl') ?? ApiEndPoints.questionList;
+  const url = opts.language ? `${listBase}?lang=${opts.language}` : listBase;
 
   const chunks: string[][] = [];
   for (let i = 0; i < identifiers.length; i += QUESTION_BATCH_SIZE) {
@@ -150,4 +164,38 @@ export async function loadQuestionSet(
     .filter((s): s is Section => Boolean(s));
 
   return { metadata: questionSet, sections };
+}
+
+/**
+ * True when a raw questionset already carries fully-authored question content
+ * embedded in its hierarchy (a leaf question has `body` or `interactions`), so it
+ * can be rendered without any network fetch. Hosts like the Sunbird editor/portal
+ * pass the whole questionset (with content) as `playerConfig.metadata`; a plain
+ * hierarchy read, by contrast, contains only stub questions (no body).
+ */
+export function hasEmbeddedQuestions(questionSet: any): boolean {
+  if (!questionSet || typeof questionSet !== 'object') return false;
+  return extractSectionNodes(questionSet).some((section) =>
+    orderedQuestionStubs(section).some(
+      (q: any) => q && (q.body || (q.interactions && Object.keys(q.interactions).length > 0)),
+    ),
+  );
+}
+
+/**
+ * Build normalized sections from a questionset whose questions are ALREADY
+ * embedded (see hasEmbeddedQuestions) — no network calls. Mirrors loadQuestionSet
+ * minus the fetch/merge: each embedded question IS the full content.
+ */
+export function transformEmbeddedQuestionSet(questionSet: any): Section[] {
+  return extractSectionNodes(questionSet)
+    .map((node): Section | null => {
+      const normalizedSection = transformSection(node);
+      if (!normalizedSection) return null;
+      const children = orderedQuestionStubs(node)
+        .map((q) => transformQuestion(q))
+        .filter((q): q is Question => Boolean(q));
+      return { ...normalizedSection, children };
+    })
+    .filter((s): s is Section => Boolean(s));
 }


### PR DESCRIPTION
  1. What/why: "Player now renders embedded questionset content directly, and falls back to host-configurable
  fetch URLs (window.questionListUrl / window.questionSetHierarchyUrl). Fixes portal 'Empty or malformed API
  response' — the player was fetching /learner/… which the portal doesn't proxy."
  2. The paired portal change — call out that this needs the portal PR (ebd61d85, sets the /portal window
  URLs) and the portal dep bump to ^0.1.3, and that they must ship together.