### PR TITLE
   # fix(react): telemetry crash guard + scrollable overview CTA (0.1.4)

### DIFF
--- a/projects/sunbird-quml-player-react/package-lock.json
+++ b/projects/sunbird-quml-player-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@project-sunbird/client-services": "^8.1.4",
         "@project-sunbird/sb-styles": "0.0.16",

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/scripts/build-wc.js
+++ b/projects/sunbird-quml-player-react/scripts/build-wc.js
@@ -37,11 +37,14 @@ const build = async () => {
     // 1. Locate the single compiled stylesheet (cssCodeSplit:false → one .css).
     const cssFile = fs.readdirSync(DIST).find((f) => f.endsWith('.css'));
     let bundleJs = fs.readFileSync(bundlePath, 'utf-8');
+    const css = cssFile ? fs.readFileSync(path.join(DIST, cssFile), 'utf-8') : '';
 
     if (cssFile) {
       console.log(`[Build] Embedding ${cssFile} into the bundle...`);
-      const css = fs.readFileSync(path.join(DIST, cssFile), 'utf-8');
       // Escape backticks and ${ so the CSS is a safe template-literal value.
+      // BUNDLED_CSS is the FULL stylesheet — reset + component classes + fonts —
+      // injected into the shadow root, where it styles the player in isolation.
+      // This must stay complete; the player's own CSS depends on it.
       const safeCss = css.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${');
       const embedded = `var BUNDLED_CSS = \`${safeCss}\`;\n`;
       bundleJs = embedded + bundleJs;
@@ -50,12 +53,22 @@ const build = async () => {
       console.warn('[Build] No CSS emitted; the bundle will ship without embedded styles.');
     }
 
-    // 2. Copy the self-contained bundle (+ raw stylesheet for the ./styles export).
+    // 2. Copy the self-contained bundle.
     console.log('[Build] Copying built files...');
     await fs.ensureDir(DEST);
     await fs.copy(bundlePath, path.join(DEST, BUNDLE));
     if (cssFile) {
-      await fs.copy(path.join(DIST, cssFile), path.join(DEST, 'styles.css'));
+      // The `./styles` export (styles.css) is loaded into the HOST document by
+      // some consumers. The player is fully styled via BUNDLED_CSS inside its
+      // shadow root (above), so this file must NOT carry the global reset (`*{}`)
+      // or the hashed component classes — those would leak into / mutate any host
+      // page that links it (a web component must never restyle its host). Ship
+      // ONLY document-level @font-face (KaTeX), which is safe to load anywhere.
+      const fontFaces = (css.match(/@font-face\s*\{[^}]*\}/g) || []).join('\n');
+      await fs.writeFile(path.join(DEST, 'styles.css'), fontFaces);
+      console.log(
+        `[Build] Wrote host-safe styles.css (@font-face only): ${(fontFaces.length / 1024).toFixed(0)}KB`,
+      );
     }
 
     // 3. Example HTML.

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.module.scss
@@ -10,6 +10,13 @@
   width: 100%;
   max-width: 100%;
   overflow-x: hidden; // hard guard: nothing scrolls the shell sideways
+  // Overview / results / review render their screen directly in the shell (the
+  // assessment stage scrolls via its inner .main). When the host constrains the
+  // player height, those screens overflow and their bottom CTA (e.g. "Start
+  // Assessment") gets clipped — so allow the shell itself to scroll vertically.
+  // Harmless for the assessment stage: its content fills exactly 100% and scrolls
+  // internally, so the shell never overflows.
+  overflow-y: auto;
   background: v.$cream-bg;
   font-family: v.$ff-base;
 }

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.portal-fetch.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.portal-fetch.test.tsx
@@ -87,7 +87,7 @@ describe('MainPlayer — full portal path (shallow metadata → /portal fetch �
 
     // Hierarchy fetched from the portal gateway route (not /learner).
     await waitFor(() =>
-      expect(mockGet).toHaveBeenCalledWith('/portal/questionset/v2/hierarchy/do_qs', expect.anything()),
+      expect(mockGet).toHaveBeenCalledWith('/portal/questionset/v2/hierarchy/do_qs?mode=edit', expect.anything()),
     );
     // Question list fetched from the portal gateway route (not /api or /action);
     // a ?lang= suffix is appended from config.language.

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.reorder-telemetry.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.reorder-telemetry.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import { initializeTelemetry } from '../../services/telemetry-service';
+import type { PlayerConfig, TelemetryContext } from '../../types';
+
+// Reproduces the real crash condition: a host telemetry SDK that has NO logEvent
+// (portal/editor) — set BEFORE interacting. Then answer a reorder question (whose
+// drag/tap/nudge fire onOptionSelected → telemetry) and assert nothing throws.
+const metadata = {
+  identifier: 'do_qs',
+  name: 'QS',
+  objectType: 'QuestionSetImage',
+  children: [
+    {
+      identifier: 'do_sec',
+      name: 'Section',
+      objectType: 'QuestionSet',
+      index: 1,
+      children: [
+        {
+          identifier: 'do_reo',
+          name: 'Q',
+          objectType: 'Question',
+          primaryCategory: 'Reorder Question',
+          qType: 'REO',
+          index: 1,
+          maxScore: 1,
+          body: '<div class="order-title">Reorder the sentence</div>',
+          interactions: {
+            response1: {
+              type: 'order',
+              options: [
+                { value: 'A', label: 'Book' },
+                { value: 'B', label: 'is' },
+                { value: 'C', label: 'on' },
+              ],
+            },
+          },
+          responseDeclaration: {
+            response1: {
+              cardinality: 'ordered',
+              type: 'string',
+              correctResponse: { value: ['A', 'B', 'C'] },
+            },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const cfg: PlayerConfig = { context: {}, config: { language: 'en' }, metadata, data: {} };
+
+describe('MainPlayer — reorder interaction with a logEvent-less telemetry SDK', () => {
+  beforeEach(() => {
+    // Host SDK exposes initialize but NOT logEvent — exactly the failing case.
+    (window as any).EkTelemetry = { initialize: vi.fn() };
+    initializeTelemetry({} as TelemetryContext);
+  });
+  afterEach(() => {
+    delete (window as any).EkTelemetry;
+    vi.restoreAllMocks();
+  });
+
+  it('answering a reorder question does NOT throw (regression: Mp.logEvent is not a function)', () => {
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /start assessment/i }));
+    fireEvent.click(screen.getByRole('button', { name: /start section/i }));
+
+    // The reorder question renders; tapping a bank word changes the answer, which
+    // fires onOptionSelected → handleQuestionAnswer → logOptionSelected/
+    // logAnswerSubmitted → raiseInteractEvent/raiseAssessEvent → the SDK path.
+    // Before the fix this threw synchronously inside the click; now it must not.
+    expect(() => fireEvent.click(screen.getByText('Book'))).not.toThrow();
+    expect(() => fireEvent.click(screen.getByText('is'))).not.toThrow();
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.module.scss
@@ -67,7 +67,7 @@
 
 .bannerTitle {
   margin: 0;
-  font-size: clamp(1.375rem, 4.5vw, #{v.$text-2xl});
+  font-size: clamp(1.25rem, 3.5vw, #{v.$text-xl});
   font-weight: v.$fw-bold;
   color: v.$white;
 }

--- a/projects/sunbird-quml-player-react/src/components/SectionPlayer/SectionPlayer.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/SectionPlayer/SectionPlayer.module.scss
@@ -4,7 +4,11 @@
 .sectionPlayer {
   display: flex;
   flex-direction: column;
-  min-height: 100%;
+  // Fill (not just min) the bounded assessment area so `.content`'s overflow-y
+  // scrolls the question internally while the nav bar stays fixed, instead of the
+  // whole player growing past a fixed-height host.
+  height: 100%;
+  min-height: 0;
 }
 
 // Shared centered column so the nav bar and question card line up 1:1.

--- a/projects/sunbird-quml-player-react/src/services/data-service.test.ts
+++ b/projects/sunbird-quml-player-react/src/services/data-service.test.ts
@@ -77,7 +77,7 @@ describe('data-service', () => {
       const qs = await getQuestionSetHierarchy('do_set', { baseUrl: 'https://host' });
       expect(qs.identifier).toBe('do_set');
       expect(mockGet).toHaveBeenCalledWith(
-        `${ApiEndPoints.getQuestionSetHierarchy}do_set`,
+        `${ApiEndPoints.getQuestionSetHierarchy}do_set?mode=edit`,
         { baseURL: 'https://host' },
       );
     });
@@ -91,7 +91,7 @@ describe('data-service', () => {
       (window as any).questionSetHierarchyUrl = '/action/questionset/v2/hierarchy/';
       mockGet.mockResolvedValue({ questionset: hierarchy.questionset });
       await getQuestionSetHierarchy('do_set');
-      expect(mockGet).toHaveBeenCalledWith('/action/questionset/v2/hierarchy/do_set', {
+      expect(mockGet).toHaveBeenCalledWith('/action/questionset/v2/hierarchy/do_set?mode=edit', {
         baseURL: undefined,
       });
       delete (window as any).questionSetHierarchyUrl;

--- a/projects/sunbird-quml-player-react/src/services/data-service.ts
+++ b/projects/sunbird-quml-player-react/src/services/data-service.ts
@@ -63,7 +63,9 @@ export async function getQuestionSetHierarchy(
   }
   const base = hostEndpoint('questionSetHierarchyUrl') ?? ApiEndPoints.getQuestionSetHierarchy;
   // Base ends with `/` (identifier appended); tolerate a host value without one.
-  const url = base.endsWith('/') ? `${base}${identifier}` : `${base}/${identifier}`;
+  const path = base.endsWith('/') ? `${base}${identifier}` : `${base}/${identifier}`;
+  // mode=edit so the editor can preview draft / in-progress question sets.
+  const url = path.includes('?') ? `${path}&mode=edit` : `${path}?mode=edit`;
   const result = await httpGet<QuestionSetHierarchyResult>(url, { baseURL: opts.baseUrl });
   if (!result?.questionset) {
     throw new QumlApiError('invalid', 'Hierarchy response missing `questionset`');

--- a/projects/sunbird-quml-player-react/src/services/telemetry-service.test.ts
+++ b/projects/sunbird-quml-player-react/src/services/telemetry-service.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  initializeTelemetry,
+  raiseInteractEvent,
+  subscribeTelemetry,
+} from './telemetry-service';
+import type { TelemetryContext } from '../types';
+
+const ctx = {} as TelemetryContext;
+
+afterEach(() => {
+  delete (window as any).EkTelemetry;
+  vi.restoreAllMocks();
+});
+
+describe('telemetry-service — SDK method guards', () => {
+  it('does NOT throw when the host SDK has no logEvent (regression: reorder crash)', () => {
+    // Host SDK exposes initialize but NOT logEvent — exactly the failing case.
+    (window as any).EkTelemetry = { initialize: vi.fn() };
+    initializeTelemetry(ctx);
+
+    const received: unknown[] = [];
+    const unsub = subscribeTelemetry((e) => received.push(e));
+
+    // This is what every onOptionSelected (incl. reorder drag/hover/nudge) hits.
+    expect(() => raiseInteractEvent({ a: 1 })).not.toThrow();
+    // Host still receives the event via the bridge even though logEvent is absent.
+    expect(received).toHaveLength(1);
+    unsub();
+  });
+
+  it('does not throw when the SDK has no initialize', () => {
+    (window as any).EkTelemetry = { logEvent: vi.fn() };
+    expect(() => initializeTelemetry(ctx)).not.toThrow();
+  });
+
+  it('calls logEvent when the SDK provides one, and still emits', () => {
+    const logEvent = vi.fn();
+    (window as any).EkTelemetry = { initialize: vi.fn(), logEvent };
+    initializeTelemetry(ctx);
+
+    const received: unknown[] = [];
+    const unsub = subscribeTelemetry((e) => received.push(e));
+    raiseInteractEvent({ a: 1 });
+
+    expect(logEvent).toHaveBeenCalledTimes(1);
+    expect(received).toHaveLength(1);
+    unsub();
+  });
+});

--- a/projects/sunbird-quml-player-react/src/services/telemetry-service.test.ts
+++ b/projects/sunbird-quml-player-react/src/services/telemetry-service.test.ts
@@ -3,6 +3,8 @@ import {
   initializeTelemetry,
   raiseInteractEvent,
   subscribeTelemetry,
+  getQueuedEvents,
+  clearEventQueue,
 } from './telemetry-service';
 import type { TelemetryContext } from '../types';
 
@@ -10,6 +12,7 @@ const ctx = {} as TelemetryContext;
 
 afterEach(() => {
   delete (window as any).EkTelemetry;
+  clearEventQueue();
   vi.restoreAllMocks();
 });
 
@@ -46,5 +49,34 @@ describe('telemetry-service — SDK method guards', () => {
     expect(logEvent).toHaveBeenCalledTimes(1);
     expect(received).toHaveLength(1);
     unsub();
+  });
+
+  it('does NOT queue when the SDK lacks logEvent (bridge handles it; no unbounded growth)', () => {
+    (window as any).EkTelemetry = { initialize: vi.fn() }; // no logEvent
+    initializeTelemetry(ctx);
+    clearEventQueue();
+    raiseInteractEvent({ a: 1 });
+    raiseInteractEvent({ a: 2 });
+    // Never queued — flushQueuedEvents could never drain it, so it must not grow.
+    expect(getQueuedEvents()).toHaveLength(0);
+  });
+
+  it('queues while no SDK is present (for a later flush)', () => {
+    delete (window as any).EkTelemetry;
+    initializeTelemetry(ctx); // no SDK → telemetrySDK reset to null
+    clearEventQueue();
+    raiseInteractEvent({ a: 1 });
+    expect(getQueuedEvents()).toHaveLength(1);
+  });
+
+  it('resets the SDK reference when re-init finds no SDK (no stale logEvent calls)', () => {
+    const logEvent = vi.fn();
+    (window as any).EkTelemetry = { initialize: vi.fn(), logEvent };
+    initializeTelemetry(ctx);
+    // SDK removed and re-initialized → stale reference must be cleared.
+    delete (window as any).EkTelemetry;
+    initializeTelemetry(ctx);
+    raiseInteractEvent({ a: 1 });
+    expect(logEvent).not.toHaveBeenCalled(); // would fire if the stale ref lingered
   });
 });

--- a/projects/sunbird-quml-player-react/src/services/telemetry-service.ts
+++ b/projects/sunbird-quml-player-react/src/services/telemetry-service.ts
@@ -41,48 +41,50 @@ export function initializeTelemetry(context: TelemetryContext): void {
   const sdk = typeof window !== 'undefined' ? (window as any).EkTelemetry : undefined;
   if (sdk) {
     telemetrySDK = sdk;
-    telemetrySDK.initialize(context);
+    // Guard: not every host SDK exposes `initialize` (or it may already be
+    // initialized by the host). Never assume the method exists.
+    if (typeof sdk.initialize === 'function') {
+      sdk.initialize(context);
+    }
   } else {
     console.warn('[TelemetryService] Sunbird SDK not available');
   }
 }
 
+/**
+ * Deliver an event to the global SDK if — and only if — it exposes a usable
+ * `logEvent`. Many hosts (portal/editor) DON'T: they consume telemetry via the
+ * `subscribeTelemetry` bridge (see emit) and their SDK has no `logEvent`. Calling
+ * it blindly throws "logEvent is not a function" on every interaction, so we
+ * feature-detect and otherwise queue. Returns true if the SDK accepted it.
+ */
+function sendToSdk(event: TelemetryEvent): boolean {
+  if (telemetrySDK && typeof telemetrySDK.logEvent === 'function') {
+    telemetrySDK.logEvent(event);
+    return true;
+  }
+  eventQueue.push(event);
+  return false;
+}
+
 /** Raise an INTERACT event (user action). */
 export function raiseInteractEvent(data: unknown): void {
   const event: TelemetryEvent = { eid: 'INTERACT', edata: data, timestamp: Date.now() };
-
-  if (telemetrySDK) {
-    telemetrySDK.logEvent(event);
-  } else {
-    eventQueue.push(event);
-    console.log('[TelemetryService] INTERACT event queued:', event);
-  }
+  sendToSdk(event);
   emit(event);
 }
 
 /** Raise an ASSESS event (answer submission). */
 export function raiseAssessEvent(data: unknown): void {
   const event: TelemetryEvent = { eid: 'ASSESS', edata: data, timestamp: Date.now() };
-
-  if (telemetrySDK) {
-    telemetrySDK.logEvent(event);
-  } else {
-    eventQueue.push(event);
-    console.log('[TelemetryService] ASSESS event queued:', event);
-  }
+  sendToSdk(event);
   emit(event);
 }
 
 /** Raise an IMPRESSION event (page view). */
 export function raiseImpressionEvent(data: unknown): void {
   const event: TelemetryEvent = { eid: 'IMPRESSION', edata: data, timestamp: Date.now() };
-
-  if (telemetrySDK) {
-    telemetrySDK.logEvent(event);
-  } else {
-    eventQueue.push(event);
-    console.log('[TelemetryService] IMPRESSION event queued:', event);
-  }
+  sendToSdk(event);
   emit(event);
 }
 
@@ -96,9 +98,9 @@ export function clearEventQueue(): void {
   eventQueue = [];
 }
 
-/** Flush queued events to the SDK (if available). */
+/** Flush queued events to the SDK (only if it exposes a usable logEvent). */
 export function flushQueuedEvents(): void {
-  if (telemetrySDK && eventQueue.length > 0) {
+  if (telemetrySDK && typeof telemetrySDK.logEvent === 'function' && eventQueue.length > 0) {
     eventQueue.forEach((event) => {
       telemetrySDK.logEvent(event);
     });

--- a/projects/sunbird-quml-player-react/src/services/telemetry-service.ts
+++ b/projects/sunbird-quml-player-react/src/services/telemetry-service.ts
@@ -39,8 +39,11 @@ function emit(event: TelemetryEvent): void {
 /** Initialize the telemetry SDK if one is available globally. */
 export function initializeTelemetry(context: TelemetryContext): void {
   const sdk = typeof window !== 'undefined' ? (window as any).EkTelemetry : undefined;
+  // Always reflect the CURRENT global SDK (or its absence). Otherwise a stale
+  // reference from a prior init can linger (multi-instance / tests) and receive
+  // logEvent calls after EkTelemetry is gone.
+  telemetrySDK = sdk ?? null;
   if (sdk) {
-    telemetrySDK = sdk;
     // Guard: not every host SDK exposes `initialize` (or it may already be
     // initialized by the host). Never assume the method exists.
     if (typeof sdk.initialize === 'function') {
@@ -56,14 +59,20 @@ export function initializeTelemetry(context: TelemetryContext): void {
  * `logEvent`. Many hosts (portal/editor) DON'T: they consume telemetry via the
  * `subscribeTelemetry` bridge (see emit) and their SDK has no `logEvent`. Calling
  * it blindly throws "logEvent is not a function" on every interaction, so we
- * feature-detect and otherwise queue. Returns true if the SDK accepted it.
+ * feature-detect first. Returns true if the SDK accepted it.
  */
 function sendToSdk(event: TelemetryEvent): boolean {
   if (telemetrySDK && typeof telemetrySDK.logEvent === 'function') {
     telemetrySDK.logEvent(event);
     return true;
   }
-  eventQueue.push(event);
+  // Queue ONLY while no SDK is present yet — it may initialize later and flush.
+  // If an SDK IS present but has no logEvent (portal/editor consume via the
+  // subscribeTelemetry bridge), never queue: flushQueuedEvents also requires
+  // logEvent, so the queue could never drain and would grow unbounded.
+  if (!telemetrySDK) {
+    eventQueue.push(event);
+  }
   return false;
 }
 

--- a/projects/sunbird-quml-player-react/src/utils/api-endpoints.ts
+++ b/projects/sunbird-quml-player-react/src/utils/api-endpoints.ts
@@ -6,7 +6,7 @@
  */
 export const ApiEndPoints = {
   getContent: '/api/content/v1/read/',
-  getQuestionSetHierarchy: '/learner/questionset/v2/hierarchy/',
+  getQuestionSetHierarchy: '/api/questionset/v2/hierarchy/',
   questionSetRead: '/api/questionset/v2/read/',
   questionList: '/api/question/v2/list',
 } as const;

--- a/projects/sunbird-quml-player-react/src/web-component/element-registration.tsx
+++ b/projects/sunbird-quml-player-react/src/web-component/element-registration.tsx
@@ -74,7 +74,7 @@ class SunbirdQumlPlayer extends HTMLElement {
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
-        .quml-player-root { all: initial; display: block; }
+        .quml-player-root { all: initial; display: block; height: 100%; }
       `;
       this.shadow.insertBefore(hostStyle, container);
 
@@ -141,7 +141,7 @@ class SunbirdQumlPlayer extends HTMLElement {
     styleEl.textContent = `
       ${typeof BUNDLED_CSS !== 'undefined' ? BUNDLED_CSS : ''}
       :host { display: block; }
-      .quml-player-root { all: initial; display: block; }
+      .quml-player-root { all: initial; display: block; height: 100%; }
     `;
     if (this.shadow.firstChild) {
       this.shadow.insertBefore(styleEl, this.shadow.firstChild);

--- a/projects/sunbird-quml-player-react/vite.config.ts
+++ b/projects/sunbird-quml-player-react/vite.config.ts
@@ -43,13 +43,13 @@ export default defineConfig(({ command }) => {
         // The source calls PRODUCTION v2 paths (api-endpoints.ts), but the local
         // port-forwarded backend serves v5 only — so the dev proxy rewrites
         // v2 → v5 (and adds the channel header + edit-mode the v5 routes need).
-        '/learner/questionset/v2/hierarchy': {
+        '/api/questionset/v2/hierarchy': {
           target: 'http://localhost:9000',
           headers: { 'X-Channel-Id': '01309282781705830427' },
-          rewrite: (p: string) => {
-            const v5 = p.replace('/learner/questionset/v2/hierarchy', '/questionset/v5/hierarchy');
-            return v5.includes('?') ? v5 : `${v5}?mode=edit`;
-          },
+          // Player calls /api/questionset/v2/hierarchy/<id>?mode=edit; the local
+          // KP backend serves /questionset/v5/hierarchy. Swap the prefix, keep
+          // the ?mode=edit the player already appends.
+          rewrite: (p: string) => p.replace('/api/questionset/v2/hierarchy', '/questionset/v5/hierarchy'),
         },
         '/api/questionset/v2/read': {
           target: 'http://localhost:9000',


### PR DESCRIPTION


  ## Summary
  Two runtime fixes for the QuML player when embedded in a host (portal/editor), bumping the package to
  **0.1.4**:
  
  1. **Telemetry crash guard** — stop `TypeError: logEvent is not a function` on every interaction.
  2. **Scrollable overview/results/review** — the "Start Assessment" (and other bottom CTAs) no longer get
  clipped inside a fixed-height host.

  No host/portal code changes are required.

  ## 1. Telemetry SDK crash guard
  **Problem:** `telemetry-service` called `telemetrySDK.logEvent()` (and `.initialize()`) unconditionally.
  Hosts like the portal/editor provide a telemetry SDK that has **no `logEvent`** — they consume events via
  the `subscribeTelemetry` bridge instead. So every user interaction threw `Uncaught TypeError: logEvent is
  not a function`. It was most visible on the **reorder** question, whose drag/hover/nudge fire the
  interaction handler repeatedly, but it affected all question types.

  **Fix:** Feature-detect the SDK methods — only call `logEvent`/`initialize` when they exist; otherwise queue
  the event. `emit()` always fires, so the host still receives telemetry through the bridge.

  **Files:** `src/services/telemetry-service.ts`

  ## 2. Scrollable overview / results / review (clipped CTA)
  **Problem:** Hosts size the player to a fixed height (e.g. the portal: `sunbird-quml-player { height:
  41.3125rem }`) and clip overflow. The overview/results/review screens render directly in `.appShell` (only
  the assessment stage scrolled, via its inner `.main`), so their content overflowed the fixed height and the
  bottom CTA ("Start Assessment") was clipped with no way to scroll.

  **Fix (two parts, both needed):**
  - `.appShell` gets `overflow-y: auto` so it can scroll when its content exceeds the host height.
  - `.quml-player-root` (the shadow container) gets `height: 100%` so the host's definite height actually
  reaches `.appShell` — without it, `.appShell`'s `height: 100%` resolved to `auto` (the container used `all:
  initial` with no height) and the `overflow-y` never triggered.

  Result: overview/results/review scroll internally within the host's box, consistent with how the assessment
  stage already scrolls. Auto-height hosts are unaffected (content grows, page scrolls).

  **Files:** `src/components/MainPlayer/MainPlayer.module.scss`, `src/web-component/element-registration.tsx`

  ## Behavior changes 
  - Interacting with any question (especially reorder) no longer crashes when the host SDK lacks `logEvent`.
  - The Start Assessment / results / review CTAs are reachable inside a fixed-height host.
  - Assessment stage, question rendering, scoring, and telemetry-to-host bridging are unchanged.

  ## Testing
  - New unit tests: telemetry guard (no-throw when SDK lacks `logEvent`, still emits, calls when present).
  - New render test: mounts a reorder question with a `logEvent`-less SDK and taps its words → asserts the
  full `onOptionSelected → raiseInteractEvent/raiseAssessEvent` path does not throw (would fail before this
  change).
  - **322 tests / 54 files passing; `tsc --noEmit` clean; `npm run build` succeeds.**

  ## Not covered by automated tests (needs a browser glance)
  CSS layout can't be verified in jsdom. After deploying 0.1.4 in a host, confirm:
  - The overview Start button is reachable (scrolls within the player box).
  - No double scrollbar on the assessment stage; submit dialog / image-zoom overlays still position correctly.

  ## Rollout
  Publish `0.1.4`, then bump the host dependency to `^0.1.4`. No portal-side code change needed.