### PR TITLE
fix(react): gate the assessment timer behind the content showTimer flag

### DIFF
--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.test.tsx
@@ -9,6 +9,8 @@ const cfg: PlayerConfig = {
   context: {},
   config: { language: 'en', showFeedback: true },
   data: {
+    // Timer is opt-in (Angular parity): content must set showTimer for it to show.
+    showTimer: true,
     sections: [
       {
         identifier: 's1',
@@ -139,6 +141,32 @@ describe('MainPlayer', () => {
       fireEvent.click(screen.getByRole('button', { name: /start section/i }));
       act(() => vi.advanceTimersByTime(2000));
       expect(screen.getByText('4:55')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('shows NO timer when showTimer is absent/false, even with a time limit', () => {
+    vi.useFakeTimers();
+    try {
+      // Time limit present, but showTimer omitted → the timer must not render
+      // (Angular parity: header *ngIf="showTimer").
+      const { showTimer: _omit, ...dataNoTimer } = cfg.data as Record<string, unknown>;
+      const noTimerCfg = {
+        ...cfg,
+        data: { ...dataNoTimer, timeLimits: { questionSet: { max: 300, min: 0 } } },
+      } as PlayerConfig;
+      render(
+        <QumlProvider playerConfig={noTimerCfg}>
+          <MainPlayer playerConfig={noTimerCfg} />
+        </QumlProvider>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: /start assessment/i }));
+      act(() => vi.advanceTimersByTime(3000));
+      expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByRole('button', { name: /start section/i }));
+      act(() => vi.advanceTimersByTime(2000));
+      expect(screen.queryByRole('timer')).not.toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -209,6 +209,10 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
       totalQuestions,
       totalSections: state.sections.length,
       timeLimit: Number(timeLimits?.max) || 0,
+      // Angular parity (main-player.component.ts:172 → header *ngIf="showTimer"):
+      // the timer is shown ONLY when the content opts in via `showTimer`. Absent /
+      // false → no timer at all; the count-up fallback also requires it.
+      showTimer: data.showTimer === true || data.showTimer === 'true',
       maxScore,
       attemptsLeft: Math.max(0, (cfg.maxAttempts ?? 3) - (state.attemptNumber - 1)),
     };
@@ -248,7 +252,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const [timeElapsed, setTimeElapsed] = useState(0);
   const elapsedAnchorRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!isClockRunning || overview.timeLimit > 0) return;
+    if (!isClockRunning || overview.timeLimit > 0 || !overview.showTimer) return;
     elapsedAnchorRef.current = Date.now() - timeElapsed * 1000;
     const id = setInterval(() => {
       setTimeElapsed(Math.floor((Date.now() - elapsedAnchorRef.current!) / 1000));
@@ -257,7 +261,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     // Re-anchor only when the clock starts/stops; timeElapsed is read once as
     // the resume point.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isClockRunning, overview.timeLimit]);
+  }, [isClockRunning, overview.timeLimit, overview.showTimer]);
 
   // Time up → auto-submit straight to results (no confirmation dialog).
   useEffect(() => {
@@ -284,7 +288,11 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
 
   // ── Flow transitions ───────────────────────────────────────────────────────
   const beginAssessmentTimer = () => {
-    if (timeRemaining == null && overview.timeLimit > 0) setTimeRemaining(overview.timeLimit);
+    // No countdown (and therefore no auto-submit on expiry) unless the content
+    // opts into the timer — Angular's header never starts the interval otherwise.
+    if (overview.showTimer && timeRemaining == null && overview.timeLimit > 0) {
+      setTimeRemaining(overview.timeLimit);
+    }
   };
 
   const handleStart = () => {
@@ -448,9 +456,9 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
         />
       );
 
-    // The header timer ALWAYS shows (intentional deviation from Angular's
-    // content-driven showTimer flag): countdown when a time limit exists,
-    // count-up elapsed otherwise.
+    // The header timer is gated by the content's `showTimer` flag (Angular parity).
+    // When enabled: countdown if a time limit exists, count-up elapsed otherwise.
+    // When disabled: both props are null, so PlayerHeader renders no timer at all.
     content = (
       <>
         <PlayerHeader
@@ -458,8 +466,8 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
           sections={state.sections}
           currentSectionIndex={state.currentSectionIndex}
           completed={completed}
-          timeRemaining={timeRemaining}
-          timeElapsed={overview.timeLimit === 0 ? timeElapsed : null}
+          timeRemaining={overview.showTimer ? timeRemaining : null}
+          timeElapsed={overview.showTimer && overview.timeLimit === 0 ? timeElapsed : null}
           questionNumber={globalQuestionNumber}
           totalQuestions={overview.totalQuestions}
           onSubmit={handleSubmitAssessment}


### PR DESCRIPTION
Match Angular: the header timer shows only when the questionset metadata opts in via showTimer. Absent/false -> no timer at all (and no auto-submit on expiry); the count-up fallback also requires it.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules