### PR TITLE
fix(react): omit Results Time Taken when the timer is suppressed

### DIFF
--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.test.tsx
@@ -146,15 +146,17 @@ describe('MainPlayer', () => {
     }
   });
 
-  it('shows NO timer when showTimer is absent/false, even with a time limit', () => {
+  // Both the omitted case and an explicit `showTimer: false` must suppress the
+  // timer (Angular parity: header *ngIf="showTimer"), even with a time limit.
+  it.each([
+    ['omitted', (() => { const { showTimer: _o, ...rest } = cfg.data as Record<string, unknown>; return rest; })()],
+    ['explicit false', { ...(cfg.data as Record<string, unknown>), showTimer: false }],
+  ])('shows NO timer when showTimer is %s, even with a time limit', (_label, data) => {
     vi.useFakeTimers();
     try {
-      // Time limit present, but showTimer omitted → the timer must not render
-      // (Angular parity: header *ngIf="showTimer").
-      const { showTimer: _omit, ...dataNoTimer } = cfg.data as Record<string, unknown>;
       const noTimerCfg = {
         ...cfg,
-        data: { ...dataNoTimer, timeLimits: { questionSet: { max: 300, min: 0 } } },
+        data: { ...data, timeLimits: { questionSet: { max: 300, min: 0 } } },
       } as PlayerConfig;
       render(
         <QumlProvider playerConfig={noTimerCfg}>

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -410,8 +410,12 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   } else if (stage === 'results') {
     // Total time spent: countdown mode → limit minus what was left; count-up
     // mode → the elapsed counter (both tick only during the assessment stage).
-    const timeTaken =
-      overview.timeLimit > 0
+    // When the timer is suppressed (showTimer off) neither clock runs, so there
+    // is no meaningful elapsed value — pass null so Results omits "Time Taken"
+    // rather than showing a misleading 0:00.
+    const timeTaken = !overview.showTimer
+      ? null
+      : overview.timeLimit > 0
         ? overview.timeLimit - (timeRemaining ?? overview.timeLimit)
         : timeElapsed;
     content = (


### PR DESCRIPTION
Address PR #154 review: with showTimer off neither clock runs, so pass timeTaken=null to ResultsScreen instead of showing a misleading 0:00 for timed sets. Also cover the explicit showTimer:false case in the test.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules