### PR TITLE
fix(react): mobile web-component height + editor preview parity (0.1.6)

### DIFF
--- a/projects/sunbird-quml-player-react/package-lock.json
+++ b/projects/sunbird-quml-player-react/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@project-sunbird/client-services": "^8.1.4",
         "@project-sunbird/sb-styles": "0.0.16",

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.preview-config.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.preview-config.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import type { PlayerConfig } from '../../types';
+
+// Embedded single-question config, mirroring what the editor's single-question
+// preview sends. `showStartPage` / `requiresSubmit` live on the questionset
+// metadata (here, alongside the embedded sections → metadata === data).
+const buildConfig = (overrides: {
+  showStartPage?: string;
+  requiresSubmit?: string;
+  showSectionIntro?: boolean;
+}): PlayerConfig => ({
+  context: {},
+  config: {
+    language: 'en',
+    showFeedback: true,
+    ...(overrides.showSectionIntro !== undefined
+      ? { showSectionIntro: overrides.showSectionIntro }
+      : {}),
+  },
+  data: {
+    ...(overrides.showStartPage !== undefined ? { showStartPage: overrides.showStartPage } : {}),
+    ...(overrides.requiresSubmit !== undefined ? { requiresSubmit: overrides.requiresSubmit } : {}),
+    sections: [
+      {
+        identifier: 's1',
+        name: 'Section 1',
+        timeLimits: { questionSet: { max: 0, min: 0 } },
+        children: [
+          {
+            identifier: 'q1',
+            body: '<p>Q1</p>',
+            primaryCategory: 'Multiple Choice Question',
+            interactions: {
+              response1: { options: [{ value: 0, label: 'Apple' }, { value: 1, label: 'Banana' }] },
+            },
+            responseDeclaration: {
+              response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 0 } },
+            },
+          },
+        ],
+      },
+    ],
+  },
+});
+
+const renderPlayer = (cfg: PlayerConfig) =>
+  render(
+    <QumlProvider playerConfig={cfg}>
+      <MainPlayer playerConfig={cfg} />
+    </QumlProvider>,
+  );
+
+describe('MainPlayer — preview parity (showStartPage / requiresSubmit)', () => {
+  it('showStartPage:"No" skips the overview and lands on the section intro', () => {
+    renderPlayer(buildConfig({ showStartPage: 'No' }));
+    // The overview "Start Assessment" CTA is never shown…
+    expect(screen.queryByRole('button', { name: /start assessment/i })).not.toBeInTheDocument();
+    // …we auto-advance to where Start would land (section intro, since intros
+    // are enabled by default).
+    expect(screen.getByRole('button', { name: /start section/i })).toBeInTheDocument();
+  });
+
+  it('showStartPage:"No" + showSectionIntro:false lands directly on the question', () => {
+    renderPlayer(buildConfig({ showStartPage: 'No', showSectionIntro: false }));
+    expect(screen.queryByRole('button', { name: /start assessment/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /start section/i })).not.toBeInTheDocument();
+    // Straight into the first question.
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.getByText(/Question 1 of 1/i)).toBeInTheDocument();
+  });
+
+  it('still shows the overview by default (showStartPage absent)', () => {
+    renderPlayer(buildConfig({}));
+    expect(screen.getByRole('button', { name: /start assessment/i })).toBeInTheDocument();
+  });
+
+  it('requiresSubmit:"No" submits straight to results with no confirmation dialog', () => {
+    vi.useFakeTimers();
+    try {
+      // Land directly on the question (showStartPage/showSectionIntro skipped)
+      // so we can exercise the submit path in isolation.
+      renderPlayer(
+        buildConfig({ requiresSubmit: 'No', showStartPage: 'No', showSectionIntro: false }),
+      );
+      // On the only question; the bottom action is the final Submit.
+      const submits = screen.getAllByRole('button', { name: /^submit$/i });
+      fireEvent.click(submits[submits.length - 1]);
+      act(() => vi.advanceTimersByTime(1000)); // feedback dwell then proceed
+      // No confirmation dialog — straight to the results screen.
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /review all answers/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.preview-config.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.preview-config.test.tsx
@@ -54,17 +54,10 @@ const renderPlayer = (cfg: PlayerConfig) =>
   );
 
 describe('MainPlayer — preview parity (showStartPage / requiresSubmit)', () => {
-  it('showStartPage:"No" skips the overview and lands on the section intro', () => {
+  it('showStartPage:"No" lands directly on the question (skips overview AND section intro — Angular parity)', () => {
+    // Section intros are enabled by default (no showSectionIntro), yet the entry
+    // still bypasses both the overview and the intro screen.
     renderPlayer(buildConfig({ showStartPage: 'No' }));
-    // The overview "Start Assessment" CTA is never shown…
-    expect(screen.queryByRole('button', { name: /start assessment/i })).not.toBeInTheDocument();
-    // …we auto-advance to where Start would land (section intro, since intros
-    // are enabled by default).
-    expect(screen.getByRole('button', { name: /start section/i })).toBeInTheDocument();
-  });
-
-  it('showStartPage:"No" + showSectionIntro:false lands directly on the question', () => {
-    renderPlayer(buildConfig({ showStartPage: 'No', showSectionIntro: false }));
     expect(screen.queryByRole('button', { name: /start assessment/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /start section/i })).not.toBeInTheDocument();
     // Straight into the first question.
@@ -72,9 +65,17 @@ describe('MainPlayer — preview parity (showStartPage / requiresSubmit)', () =>
     expect(screen.getByText(/Question 1 of 1/i)).toBeInTheDocument();
   });
 
-  it('still shows the overview by default (showStartPage absent)', () => {
-    renderPlayer(buildConfig({}));
-    expect(screen.getByRole('button', { name: /start assessment/i })).toBeInTheDocument();
+  it('normal content still shows the overview then the section intro (feature intact)', () => {
+    renderPlayer(buildConfig({})); // no showStartPage → default flow
+    // 1. Overview first.
+    const start = screen.getByRole('button', { name: /start assessment/i });
+    expect(screen.queryByText('Apple')).not.toBeInTheDocument();
+    // 2. Start → section intro (intros default on, NOT skipped for normal content).
+    fireEvent.click(start);
+    const begin = screen.getByRole('button', { name: /start section/i });
+    // 3. Begin → the question.
+    fireEvent.click(begin);
+    expect(screen.getByText('Apple')).toBeInTheDocument();
   });
 
   it('requiresSubmit:"No" submits straight to results with no confirmation dialog', () => {

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.preview-config.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.preview-config.test.tsx
@@ -78,6 +78,25 @@ describe('MainPlayer — preview parity (showStartPage / requiresSubmit)', () =>
     expect(screen.getByText('Apple')).toBeInTheDocument();
   });
 
+  it('with showStartPage:"No", an explicit return to overview (Retake) shows it, not a stuck loader', () => {
+    vi.useFakeTimers();
+    try {
+      renderPlayer(buildConfig({ showStartPage: 'No', requiresSubmit: 'No' }));
+      // Initial: skipped overview, landed on the question.
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+      // Submit (no confirmation) → results.
+      const submits = screen.getAllByRole('button', { name: /^submit$/i });
+      fireEvent.click(submits[submits.length - 1]);
+      act(() => vi.advanceTimersByTime(1000));
+      // Retake → returns to overview. The one-shot auto-start does NOT re-fire,
+      // so the overview must actually render (regression: was a stuck loader).
+      fireEvent.click(screen.getByRole('button', { name: /retake/i }));
+      expect(screen.getByRole('button', { name: /start assessment/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('requiresSubmit:"No" submits straight to results with no confirmation dialog', () => {
     vi.useFakeTimers();
     try {

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -392,15 +392,22 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setStage('assessment');
   };
 
-  // showStartPage:'No' → auto-advance past the overview once sections are ready,
-  // landing exactly where "Start" would. One-shot (ref-guarded) so an explicit
-  // later return to overview (retake / brand click) is still respected.
+  // showStartPage:'No' → auto-advance past the overview once sections are ready.
+  // Angular parity (section-player.component.ts:195,248): with showStartPage:'No'
+  // the player renders the FIRST QUESTION directly — no overview AND no section
+  // intro (the intro screen is a React-only addition). So land on 'assessment',
+  // not 'sectionIntro'. Later section-to-section intros are unaffected.
+  // One-shot (ref-guarded) so an explicit later return to overview (retake /
+  // brand click) is still respected.
   useEffect(() => {
     if (autoStartedRef.current || !skipStartPage) return;
     if (stage !== 'overview' || state.sections.length === 0) return;
     autoStartedRef.current = true;
-    handleStart();
-    // Guarded by the ref; handleStart is intentionally not a dependency.
+    setCurrentSection(0);
+    setCurrentQuestion(0);
+    beginAssessmentTimer();
+    setStage('assessment');
+    // Guarded by the ref; the setters/timer are stable enough here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [skipStartPage, stage, state.sections.length]);
 

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -76,10 +76,22 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const [reviewStartIndex, setReviewStartIndex] = useState(0);
   // Assessment-level countdown (owned by the shell, not Context). Null = no limit.
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
+  // One-shot guard for the showStartPage:'No' auto-advance past the overview.
+  const autoStartedRef = useRef(false);
 
   // Section intros can be disabled via config (spec §6.0).
   const sectionIntrosEnabled =
     (playerConfig?.config as { showSectionIntro?: boolean } | undefined)?.showSectionIntro !== false;
+
+  // Preview parity (Angular): the host can ask the player to skip the overview /
+  // start page and the submit-confirmation step. These arrive on the questionset
+  // metadata as 'Yes'/'No' strings. Absent → the full behaviour (show overview,
+  // confirm on submit), so existing content is unaffected.
+  //   showStartPage:'No'  → land straight in the assessment (see auto-start effect)
+  //   requiresSubmit:'No' → Submit goes straight to results, no confirmation modal
+  const skipStartPage = metadata.showStartPage === 'No' || metadata.showStartPage === false;
+  const requiresSubmitConfirmation =
+    metadata.requiresSubmit !== 'No' && metadata.requiresSubmit !== false;
 
   // Initialize config + normalized sections.
   //
@@ -325,8 +337,12 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setStage(sectionIntrosEnabled ? 'sectionIntro' : 'assessment');
   };
 
-  // Submit (header) → open the confirmation dialog (spec §7.1).
-  const handleSubmitAssessment = () => setSubmitDialog(true);
+  // Submit (header) → open the confirmation dialog (spec §7.1), unless the host
+  // opted out via requiresSubmit:'No' (then submit straight to results).
+  const handleSubmitAssessment = () => {
+    if (requiresSubmitConfirmation) setSubmitDialog(true);
+    else handleConfirmSubmit();
+  };
 
   const handleConfirmSubmit = () => {
     setSubmitDialog(false);
@@ -362,9 +378,11 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
       setCurrentQuestion(0);
       setStage(sectionIntrosEnabled ? 'sectionIntro' : 'assessment');
       onPlayerEvent?.({ type: 'sectionEnd', sectionIndex: state.currentSectionIndex });
-    } else {
+    } else if (requiresSubmitConfirmation) {
       // End of the last section → confirm before submitting.
       setSubmitDialog(true);
+    } else {
+      handleConfirmSubmit();
     }
   };
 
@@ -373,6 +391,18 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setCurrentQuestion(0);
     setStage('assessment');
   };
+
+  // showStartPage:'No' → auto-advance past the overview once sections are ready,
+  // landing exactly where "Start" would. One-shot (ref-guarded) so an explicit
+  // later return to overview (retake / brand click) is still respected.
+  useEffect(() => {
+    if (autoStartedRef.current || !skipStartPage) return;
+    if (stage !== 'overview' || state.sections.length === 0) return;
+    autoStartedRef.current = true;
+    handleStart();
+    // Guarded by the ref; handleStart is intentionally not a dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [skipStartPage, stage, state.sections.length]);
 
   if (!state.playerConfig || state.loading) {
     return <div className={styles.status}>{t(language, 'LOADING')}</div>;
@@ -402,7 +432,10 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const globalQuestionNumber = priorQuestions + state.currentQuestionIndex + 1;
 
   let content: ReactNode;
-  if (stage === 'overview') {
+  if (stage === 'overview' && skipStartPage) {
+    // Auto-advancing (effect above) — don't flash the overview we're skipping.
+    content = <div className={styles.status}>{t(language, 'LOADING')}</div>;
+  } else if (stage === 'overview') {
     content = (
       <StartPage
         title={overview.title}

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -439,8 +439,11 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const globalQuestionNumber = priorQuestions + state.currentQuestionIndex + 1;
 
   let content: ReactNode;
-  if (stage === 'overview' && skipStartPage) {
-    // Auto-advancing (effect above) — don't flash the overview we're skipping.
+  if (stage === 'overview' && skipStartPage && !autoStartedRef.current) {
+    // Initial auto-start still pending (effect above) — don't flash the overview
+    // we're skipping. Gated on the ref so that an EXPLICIT later return to
+    // overview (Retake / brand click) shows the real overview instead of a
+    // permanent loading screen (the one-shot effect won't re-fire).
     content = <div className={styles.status}>{t(language, 'LOADING')}</div>;
   } else if (stage === 'overview') {
     content = (

--- a/projects/sunbird-quml-player-react/src/styles/global.scss
+++ b/projects/sunbird-quml-player-react/src/styles/global.scss
@@ -9,7 +9,15 @@
 html,
 body,
 #root {
+  // Track the DYNAMIC viewport, not a fixed 100%. On a real phone, `height: 100%`
+  // resolves to the LARGE viewport (address bar hidden), so the visible area is
+  // shorter than the app — the bottom of a screen ends up under the address bar
+  // and, because the height is locked, nothing scrolls to reveal it (frozen page).
+  // `dvh` shrinks/grows with the browser chrome so the shell always matches what
+  // the user can see; `%` then `vh` are fallbacks for browsers without `dvh`.
   height: 100%;
+  height: 100vh;
+  height: 100dvh;
   margin: 0;
   padding: 0;
 }

--- a/projects/sunbird-quml-player-react/src/web-component/element-registration.tsx
+++ b/projects/sunbird-quml-player-react/src/web-component/element-registration.tsx
@@ -67,14 +67,23 @@ class SunbirdQumlPlayer extends HTMLElement {
       const hostStyle = document.createElement('style');
       hostStyle.textContent = `
         :host {
-          display: block;
+          /* all:initial isolates us from host-page styles, but it also resets
+             display + height — so re-declare them AFTER it, or the element falls
+             back to an inline, auto-height box that can't fill its container. */
           all: initial;
+          display: block;
+          /* Fill the host's container height. Without this the custom element is
+             auto-height (content-sized), so every inner height:100% collapses and
+             the assessment stage — whose .appBody is overflow:hidden — clips the
+             question with no scroll viewport, freezing the screen on mobile. */
+          height: 100%;
+          box-sizing: border-box;
           font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
             'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
           -webkit-font-smoothing: antialiased;
           -moz-osx-font-smoothing: grayscale;
         }
-        .quml-player-root { all: initial; display: block; height: 100%; }
+        .quml-player-root { all: initial; display: block; height: 100%; box-sizing: border-box; }
       `;
       this.shadow.insertBefore(hostStyle, container);
 
@@ -140,8 +149,8 @@ class SunbirdQumlPlayer extends HTMLElement {
     const styleEl = document.createElement('style');
     styleEl.textContent = `
       ${typeof BUNDLED_CSS !== 'undefined' ? BUNDLED_CSS : ''}
-      :host { display: block; }
-      .quml-player-root { all: initial; display: block; height: 100%; }
+      :host { display: block; height: 100%; box-sizing: border-box; }
+      .quml-player-root { all: initial; display: block; height: 100%; box-sizing: border-box; }
     `;
     if (this.shadow.firstChild) {
       this.shadow.insertBefore(styleEl, this.shadow.firstChild);


### PR DESCRIPTION
- element-registration: give :host a definite height (100%) so the player fills its host container. Without it the custom element was auto-height, collapsing every inner height:100% and freezing the assessment stage in embedded / mobile-webview hosts.
- MainPlayer: honor metadata.showStartPage:'No' (skip the overview/start page) and metadata.requiresSubmit:'No' (submit straight to results, no confirmation modal) for single-question editor previews. Absent → the existing behavior, so no regression for normal content.
- global.scss: size html/body/#root to the dynamic viewport (dvh) so the standalone dev app scrolls on real mobile devices.
- bump web component to 0.1.6.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules