### PR TITLE
fix(react): play online audio/video solutions when host sets basePath

### DIFF
--- a/projects/sunbird-quml-player-react/src/utils/media.ts
+++ b/projects/sunbird-quml-player-react/src/utils/media.ts
@@ -73,15 +73,21 @@ function resolveImageSrc(val: MediaItem, ctx: MediaResolveContext, currentSrc?: 
 
 /**
  * Resolve a <video>/<audio>/<source>/poster src.
- * Mirrors Angular util-service.ts:resolveMediaElements() exactly. NOTE: the
- * offline branch here differs from images — it uses basePath directly with only
- * the question folder (no last-segment strip, no section folder). This
- * inconsistency is intentional parity with Angular. Uses the AUTHORED src.
+ * Mirrors Angular util-service.ts:resolveMediaElements(). NOTE: the offline path
+ * differs from images — it uses basePath directly with only the question folder
+ * (no last-segment strip, no section folder), which is intentional Angular
+ * parity. Like images, the offline branch is gated on isAvailableLocally so an
+ * online host that also supplies a basePath still resolves via the entry baseUrl.
  */
 function resolveAvSrc(src: string, val: MediaItem | undefined, ctx: MediaResolveContext): string {
   // Callers already skip absolute srcs; kept defensive.
   if (isHttpAbsolute(src)) return src;
-  return ctx.basePath
+  // Only take the offline (basePath) branch for packaged content, exactly like
+  // resolveImageSrc. Hosts (the mobile app) may pass a basePath even for ONLINE
+  // content; gating on basePath alone would then wrongly build an offline path
+  // for online media and break <video>/<audio> playback. isAvailableLocally is
+  // the authoritative offline flag — online media always uses the entry baseUrl.
+  return ctx.isAvailableLocally && ctx.basePath
     ? `${ctx.basePath}/${ctx.questionId}/${src}`
     : (val?.baseUrl ?? '') + src;
 }


### PR DESCRIPTION
## Problem
Online audio/video solutions (and any A/V media) did not play in host apps that pass a `basePath` for online content (e.g. the Sunbird mobile app). Both online and offline media were affected; images were fine.

## Root cause
In `projects/sunbird-quml-player-react/src/utils/media.ts`, `resolveAvSrc` decided offline-vs-online by checking `basePath` **alone**, whereas `resolveImageSrc` correctly gates on `isAvailableLocally && basePath`. When a host supplies a `basePath` for **online** content, `<video>`/`<audio>` took the offline branch and produced a malformed URL:

```
basePath/questionId//assets/public/content/assets/.../clip.webm
```

…which resolves to nothing. Images were unaffected because their resolver already gated on `isAvailableLocally`.

This regressed in the refactor that moved solution media URLs from baked-absolute to render-time resolution; before that the URL was built as `baseUrl + src` unconditionally and was immune.

## Fix
Gate the A/V offline branch on `isAvailableLocally && basePath`, matching `resolveImageSrc`:
- **Online** (not `isAvailableLocally`) → resolves via the media entry's `baseUrl` → correct absolute URL.
- **Offline** (`isAvailableLocally`) → unchanged (packaged `basePath` path).

Only `<video>`/`<audio>` src/poster/`<source>` resolution is affected. No change to images, body, options, hints, scoring, or navigation.

## Validation
- `tsc --noEmit` clean.
- Full player test suite passes (media + transform suites included).
- Device-verified in the Sunbird mobile app: online **and** offline audio/video solutions now play.