### PR TITLE
fix(react): play online audio/video solutions when host sets basePath…

### DIFF
--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/src/utils/media.test.ts
+++ b/projects/sunbird-quml-player-react/src/utils/media.test.ts
@@ -99,5 +99,20 @@ describe('resolveMediaHtml', () => {
       // A/V offline differs from images: basePath used directly + question only.
       expect(out).toContain('src="/data/content/set.json/do_q/clip.mp4"');
     });
+
+    it('online with a basePath present (host quirk) still uses media.baseUrl — not the offline path', () => {
+      // Regression guard: hosts (e.g. the mobile app) may pass a basePath even
+      // for ONLINE content. The offline branch is gated on isAvailableLocally, so
+      // A/V must resolve via the media entry baseUrl, NOT build a basePath path.
+      const html = '<video data-asset-variable="v1"><source src="/clip.mp4"></video>';
+      const ctx: MediaResolveContext = {
+        media,
+        basePath: '/data/content/set.json', // present, but isAvailableLocally is falsy
+        questionId: 'do_q',
+      };
+      const out = resolveMediaHtml(html, ctx);
+      expect(out).toContain('src="https://host/clip.mp4"');
+      expect(out).not.toContain('/data/content/set.json/');
+    });
   });
 });

--- a/projects/sunbird-quml-player-react/src/utils/media.ts
+++ b/projects/sunbird-quml-player-react/src/utils/media.ts
@@ -73,15 +73,21 @@ function resolveImageSrc(val: MediaItem, ctx: MediaResolveContext, currentSrc?: 
 
 /**
  * Resolve a <video>/<audio>/<source>/poster src.
- * Mirrors Angular util-service.ts:resolveMediaElements() exactly. NOTE: the
- * offline branch here differs from images — it uses basePath directly with only
- * the question folder (no last-segment strip, no section folder). This
- * inconsistency is intentional parity with Angular. Uses the AUTHORED src.
+ * Mirrors Angular util-service.ts:resolveMediaElements(). NOTE: the offline path
+ * differs from images — it uses basePath directly with only the question folder
+ * (no last-segment strip, no section folder), which is intentional Angular
+ * parity. Like images, the offline branch is gated on isAvailableLocally so an
+ * online host that also supplies a basePath still resolves via the entry baseUrl.
  */
 function resolveAvSrc(src: string, val: MediaItem | undefined, ctx: MediaResolveContext): string {
   // Callers already skip absolute srcs; kept defensive.
   if (isHttpAbsolute(src)) return src;
-  return ctx.basePath
+  // Only take the offline (basePath) branch for packaged content, exactly like
+  // resolveImageSrc. Hosts (the mobile app) may pass a basePath even for ONLINE
+  // content; gating on basePath alone would then wrongly build an offline path
+  // for online media and break <video>/<audio> playback. isAvailableLocally is
+  // the authoritative offline flag — online media always uses the entry baseUrl.
+  return ctx.isAvailableLocally && ctx.basePath
     ? `${ctx.basePath}/${ctx.questionId}/${src}`
     : (val?.baseUrl ?? '') + src;
 }


### PR DESCRIPTION
… (0.1.8)

resolveAvSrc gated the offline branch on basePath alone, unlike resolveImageSrc (which gates on isAvailableLocally && basePath). Hosts such as the mobile app pass a basePath even for ONLINE content, so <video>/<audio> (including solution media) took the offline branch and built a malformed `basePath/questionId//assets/public/...` URL — breaking playback both online and offline (images were unaffected because they already gated correctly).

Gate the A/V offline branch on `isAvailableLocally && basePath`, matching the image resolver. Online media now resolves via the media entry's baseUrl; genuine offline (isAvailableLocally) is unchanged.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules