### PR TITLE
React v.1

### DIFF
--- a/projects/sunbird-quml-player-react/package-lock.json
+++ b/projects/sunbird-quml-player-react/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@project-sunbird/sunbird-quml-player-web-component-react",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@project-sunbird/client-services": "^8.1.4",
         "@project-sunbird/sb-styles": "0.0.16",
         "@project-sunbird/sunbird-player-sdk-v9": "6.0.5",
@@ -361,6 +364,55 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@esbuild/android-arm": {

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -15,6 +15,9 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@project-sunbird/client-services": "^8.1.4",
     "@project-sunbird/sb-styles": "0.0.16",
     "@project-sunbird/sunbird-player-sdk-v9": "6.0.5",

--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/src/components/questions/MtfQuestion/MtfQuestion.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/questions/MtfQuestion/MtfQuestion.module.scss
@@ -48,6 +48,9 @@ $mtf-row-height: 6.5rem;
   border: 1.5px solid v.$gray-200;
   cursor: grab;
   box-shadow: v.$shadow-card;
+  // Guard against text/image selection during a mouse drag.
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 .arrow {
@@ -63,11 +66,6 @@ $mtf-row-height: 6.5rem;
 .dragging {
   opacity: 0.45;
   border-color: v.$brick;
-}
-
-.over {
-  border: 2px dashed v.$brick;
-  background: v.$brick-lt;
 }
 
 .term {

--- a/projects/sunbird-quml-player-react/src/components/questions/MtfQuestion/MtfQuestion.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/MtfQuestion/MtfQuestion.test.tsx
@@ -1,8 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
-import type { ReactNode } from 'react';
 import { MtfQuestion } from './MtfQuestion';
 import type { Question } from '../../../types';
 
@@ -30,11 +27,11 @@ const mtfQuestion = {
   },
 } as Question;
 
-const withDnd = (ui: ReactNode) => render(<DndProvider backend={HTML5Backend}>{ui}</DndProvider>);
-
+// MtfQuestion provides its own dnd-kit DndContext, so no external DnD provider
+// is needed (unlike the old react-dnd version).
 describe('MtfQuestion', () => {
   it('renders each left prompt with its right answer image (no drop-here slots)', () => {
-    withDnd(<MtfQuestion question={mtfQuestion} shuffleOptions={false} />);
+    render(<MtfQuestion question={mtfQuestion} shuffleOptions={false} />);
     // Left prompts.
     expect(screen.getByText('France')).toBeInTheDocument();
     expect(screen.getByText('Japan')).toBeInTheDocument();
@@ -46,7 +43,7 @@ describe('MtfQuestion', () => {
 
   it('restores a saved arrangement into the right cells', () => {
     // Saved: A→2 (Tokyo), B→1 (Paris) — i.e. swapped from the natural order.
-    withDnd(
+    render(
       <MtfQuestion question={mtfQuestion} replayed savedResponse={{ matches: { A: '2', B: '1' } }} />,
     );
     const cells = screen.getAllByText(/Paris|Tokyo/);

--- a/projects/sunbird-quml-player-react/src/components/questions/MtfQuestion/MtfQuestion.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/MtfQuestion/MtfQuestion.tsx
@@ -1,5 +1,22 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useDrag, useDrop } from 'react-dnd';
+import {
+  DndContext,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { QuestionBody } from '../../QuestionBody/QuestionBody';
 import { mtfColumns, resolveLabel } from '../question-utils';
 import { fisherYatesShuffle } from '../../../utils/shuffle';
@@ -8,46 +25,38 @@ import type { QuestionComponentProps } from '../types';
 import type { MediaItem, MediaResolveContext } from '../../../utils/media';
 import styles from './MtfQuestion.module.scss';
 
-const ITEM_TYPE = 'mtf-right';
-interface DragItem {
-  index: number;
-}
-
 interface RightCellProps {
   option: Option;
-  index: number;
+  /** Stable sortable id (the option value). */
+  id: string;
   language: string;
   mediaCtx: MediaResolveContext;
   disabled: boolean;
-  /** Swap the right images at positions `from` and `to`. */
-  onSwap: (from: number, to: number) => void;
 }
 
 /**
- * A right-column image that is both a drag source and a drop target, so the
- * learner rearranges the right images (by swapping) until the correct one sits
- * next to each left prompt.
+ * A right-column image that is a dnd-kit sortable item, so the learner drags it
+ * to a new row to rearrange the right column. dnd-kit's Mouse/Touch/Keyboard
+ * sensors make the drag work on desktop AND touch (react-dnd's HTML5 backend was
+ * mouse-only), matching the Angular CDK MTF behaviour.
  */
-function RightCell({ option, index, language, mediaCtx, disabled, onSwap }: RightCellProps) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [{ isDragging }, drag] = useDrag<DragItem, void, { isDragging: boolean }>({
-    type: ITEM_TYPE,
-    item: { index },
-    canDrag: !disabled,
-    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+function RightCell({ option, id, language, mediaCtx, disabled }: RightCellProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled,
   });
-  const [{ isOver }, drop] = useDrop<DragItem, void, { isOver: boolean }>({
-    accept: ITEM_TYPE,
-    collect: (monitor) => ({ isOver: monitor.isOver() }),
-    drop: (item) => onSwap(item.index, index),
-  });
-  drag(drop(ref));
-
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
   const label = resolveLabel(option.label, language, mediaCtx);
   return (
     <div
-      ref={ref}
-      className={`${styles.rightCell} ${isDragging ? styles.dragging : ''} ${isOver ? styles.over : ''}`.trim()}
+      ref={setNodeRef}
+      style={style}
+      className={`${styles.rightCell} ${isDragging ? styles.dragging : ''}`.trim()}
+      {...attributes}
+      {...listeners}
       dangerouslySetInnerHTML={{ __html: label }}
     />
   );
@@ -56,9 +65,9 @@ function RightCell({ option, index, language, mediaCtx, disabled, onSwap }: Righ
 /**
  * MTF (Match The Following) — pure renderer. Each left prompt sits on a row with
  * its answer image on the right; the right images start shuffled and the learner
- * drags/swaps them so the correct image lands next to each prompt. Emits
- * { matches: { leftValue: rightValue } } (rightValue = whatever sits in that
- * row's right cell). Assumes a DndProvider ancestor.
+ * drags them to reorder the right column so the correct image lands next to each
+ * prompt. Emits { matches: { leftValue: rightValue } } (rightValue = whatever
+ * sits in that row's right cell).
  */
 export function MtfQuestion({
   question,
@@ -108,48 +117,64 @@ export function MtfQuestion({
     onOptionSelected?.({ matches, timestamp: Date.now() });
   };
 
-  const swap = (from: number, to: number) => {
-    if (replayed || from === to) return;
-    const next = [...order];
-    [next[from], next[to]] = [next[to], next[from]];
+  // dnd-kit sensors: Mouse for desktop (immediate), Touch with a short press
+  // delay so the page can still scroll until a drag is intended, Keyboard for a11y.
+  const sensors = useSensors(
+    useSensor(MouseSensor),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (replayed || !over || active.id === over.id) return;
+    const from = order.findIndex((o) => String(o.value) === active.id);
+    const to = order.findIndex((o) => String(o.value) === over.id);
+    if (from < 0 || to < 0) return;
+    const next = arrayMove(order, from, to);
     setOrder(next);
     emit(next);
   };
+
+  const sortableIds = order.map((o) => String(o.value));
 
   return (
     <div className={styles.mtf}>
       <QuestionBody question={question} language={language} mediaCtx={ctx} />
 
       {/* Brown board: each row is a left prompt with its answer image on the
-          right; the right images are draggable and swap on drop.
+          right; the right images are draggable and reorder on drop.
           dir="ltr": the board keeps its prompt-left / draggable-right layout
           even in the RTL (Arabic) UI — mirroring it moved the DRAGGABLE column
           to the left while learners kept grabbing the (static) right one. */}
-      <div className={styles.board} dir="ltr">
-        {left.map((l, i) => (
-          <div className={styles.row} key={String(l.value)}>
-            <div className={styles.leftCard}>
-              <span
-                className={styles.term}
-                dangerouslySetInnerHTML={{ __html: resolveLabel(l.label, language, ctx) }}
-              />
-            </div>
-            <span className={styles.arrow} aria-hidden="true">
-              →
-            </span>
-            {order[i] && (
-              <RightCell
-                option={order[i]}
-                index={i}
-                language={language}
-                mediaCtx={ctx}
-                disabled={replayed}
-                onSwap={swap}
-              />
-            )}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+          <div className={styles.board} dir="ltr">
+            {left.map((l, i) => (
+              <div className={styles.row} key={String(l.value)}>
+                <div className={styles.leftCard}>
+                  <span
+                    className={styles.term}
+                    dangerouslySetInnerHTML={{ __html: resolveLabel(l.label, language, ctx) }}
+                  />
+                </div>
+                <span className={styles.arrow} aria-hidden="true">
+                  →
+                </span>
+                {order[i] && (
+                  <RightCell
+                    id={String(order[i].value)}
+                    option={order[i]}
+                    language={language}
+                    mediaCtx={ctx}
+                    disabled={replayed}
+                  />
+                )}
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        </SortableContext>
+      </DndContext>
     </div>
   );
 }

--- a/projects/sunbird-quml-player-react/src/components/questions/ReoQuestion/ReoQuestion.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/ReoQuestion/ReoQuestion.tsx
@@ -170,7 +170,6 @@ export function ReoQuestion({
               onClick={() => removeWord(word.value)}
             >
               <span dangerouslySetInnerHTML={{ __html: resolveLabel(word.label, language, ctx) }} />
-              {!replayed && <span aria-hidden="true"> ×</span>}
             </button>
           ))
         )}

--- a/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.module.scss
@@ -10,6 +10,10 @@
   gap: v.$space-3;
 }
 
+// The whole row is the drag handle. The dnd-kit TouchSensor press-delay (150ms)
+// disambiguates a drag from a scroll, so we DON'T set touch-action:none (that
+// would block page scrolling) — same setup as the MTF draggable. cursor:grab is
+// the desktop affordance; user-select:none stops text selection mid-drag.
 .row {
   display: flex;
   align-items: center;
@@ -20,7 +24,13 @@
   border-radius: v.$r-md;
   box-shadow: v.$shadow-card;
   cursor: grab;
+  user-select: none;
+  -webkit-user-select: none;
   transition: border-color v.$dur-fast v.$ease-out, background v.$dur-fast v.$ease-out;
+
+  &:active {
+    cursor: grabbing;
+  }
 }
 
 .dragging {
@@ -28,15 +38,10 @@
   border-color: v.$brick;
 }
 
-.over {
-  border-color: v.$wave;
-  background: v.$info-bg;
-}
-
+// Visual "draggable" affordance only — the whole row is draggable, not just this.
 .grip {
   color: v.$g300;
   font-size: v.$text-md;
-  cursor: grab;
 }
 
 .label {
@@ -47,43 +52,6 @@
 
   :global(p) {
     margin: 0;
-  }
-}
-
-.controls {
-  display: inline-flex;
-  gap: v.$space-1;
-}
-
-.nudge {
-  @include m.focus-ring;
-
-  width: 28px;
-  height: 28px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: v.$white;
-  border: 1.5px solid v.$gray-200;
-  border-radius: v.$r-sm;
-  color: v.$g600;
-  cursor: pointer;
-
-  &:hover:not(:disabled) {
-    border-color: v.$brick;
-    color: v.$brick;
-  }
-
-  &:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-
-  // Comfortable touch target on mobile (drag is hard on touch — these are the
-  // primary reordering control there).
-  @include m.mobile {
-    width: 2.75rem;
-    height: 2.75rem;
   }
 }
 

--- a/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.test.tsx
@@ -39,10 +39,9 @@ describe('SeqQuestion', () => {
 
   it('restores saved order', () => {
     render(<SeqQuestion question={seqQuestion} savedResponse={{ order: ['c', 'b', 'a'] }} />);
-    // Query labels in DOM (row) order; the sortable <li> carries role="button"
-    // (dnd-kit), so we can't rely on the listitem role here.
-    const labels = screen.getAllByText(/First|Second|Third/).map((el) => el.textContent);
-    expect(labels[0]).toContain('Third');
-    expect(labels[2]).toContain('First');
+    // Each sortable row is a role="button" (dnd-kit) whose accessible name is the
+    // option text; read them in DOM order to assert the arrangement deterministically.
+    const order = screen.getAllByRole('button').map((el) => el.getAttribute('aria-label'));
+    expect(order).toEqual(['Third', 'Second', 'First']);
   });
 });

--- a/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.test.tsx
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
-import { DndProvider } from 'react-dnd';
-import { HTML5Backend } from 'react-dnd-html5-backend';
-import type { ReactNode } from 'react';
+import { render, screen } from '@testing-library/react';
 import { SeqQuestion } from './SeqQuestion';
 import type { Question } from '../../../types';
 
@@ -25,36 +22,27 @@ const seqQuestion = {
   },
 } as Question;
 
-const withDnd = (ui: ReactNode) => render(<DndProvider backend={HTML5Backend}>{ui}</DndProvider>);
-
+// SeqQuestion provides its own dnd-kit DndContext, so no external DnD provider
+// is needed (unlike the old react-dnd version).
 describe('SeqQuestion', () => {
   it('renders items in declared order when shuffle is off', () => {
-    withDnd(<SeqQuestion question={seqQuestion} shuffleOptions={false} />);
+    render(<SeqQuestion question={seqQuestion} shuffleOptions={false} />);
     expect(screen.getByText('First')).toBeInTheDocument();
     expect(screen.getByText('Third')).toBeInTheDocument();
   });
 
-  it('reorders via keyboard nudge and emits { order }', () => {
-    const onOptionSelected = vi.fn();
-    withDnd(
-      <SeqQuestion question={seqQuestion} shuffleOptions={false} onOptionSelected={onOptionSelected} />,
-    );
-    fireEvent.click(screen.getByRole('button', { name: /move item 1 down/i }));
-    expect(onOptionSelected).toHaveBeenLastCalledWith(
-      expect.objectContaining({ order: ['b', 'a', 'c'] }),
-    );
-  });
-
   it('calls onComponentLoaded once', () => {
     const onComponentLoaded = vi.fn();
-    withDnd(<SeqQuestion question={seqQuestion} shuffleOptions={false} onComponentLoaded={onComponentLoaded} />);
+    render(<SeqQuestion question={seqQuestion} shuffleOptions={false} onComponentLoaded={onComponentLoaded} />);
     expect(onComponentLoaded).toHaveBeenCalledTimes(1);
   });
 
   it('restores saved order', () => {
-    withDnd(<SeqQuestion question={seqQuestion} savedResponse={{ order: ['c', 'b', 'a'] }} />);
-    const items = screen.getAllByRole('listitem').map((li) => li.textContent);
-    expect(items[0]).toContain('Third');
-    expect(items[2]).toContain('First');
+    render(<SeqQuestion question={seqQuestion} savedResponse={{ order: ['c', 'b', 'a'] }} />);
+    // Query labels in DOM (row) order; the sortable <li> carries role="button"
+    // (dnd-kit), so we can't rely on the listitem role here.
+    const labels = screen.getAllByText(/First|Second|Third/).map((el) => el.textContent);
+    expect(labels[0]).toContain('Third');
+    expect(labels[2]).toContain('First');
   });
 });

--- a/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.tsx
@@ -48,12 +48,17 @@ function SeqRow({ id, index, label, disabled }: SeqRowProps) {
     transform: CSS.Transform.toString(transform),
     transition,
   };
+  // Accessible name = the option's own text (labels are HTML, so strip tags),
+  // NOT a generic "Item N" — otherwise the screen reader can't tell items apart.
+  // dnd-kit's attributes add the "sortable" roledescription + pick-up/move
+  // instructions, so we don't repeat "drag to reorder" here.
+  const name = label.replace(/<[^>]*>/g, '').trim() || `Item ${index + 1}`;
   return (
     <li
       ref={setNodeRef}
       style={style}
       className={`${styles.row} ${isDragging ? styles.dragging : ''}`.trim()}
-      aria-label={`Item ${index + 1}: drag to reorder`}
+      aria-label={name}
       {...attributes}
       {...listeners}
     >

--- a/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.tsx
+++ b/projects/sunbird-quml-player-react/src/components/questions/SeqQuestion/SeqQuestion.tsx
@@ -1,5 +1,22 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useDrag, useDrop } from 'react-dnd';
+import {
+  DndContext,
+  MouseSensor,
+  TouchSensor,
+  KeyboardSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { QuestionBody } from '../../QuestionBody/QuestionBody';
 import { firstInteractionOptions, resolveLabel } from '../question-utils';
 import { fisherYatesShuffle } from '../../../utils/shuffle';
@@ -8,80 +25,49 @@ import type { QuestionComponentProps } from '../types';
 import type { MediaItem, MediaResolveContext } from '../../../utils/media';
 import styles from './SeqQuestion.module.scss';
 
-const ITEM_TYPE = 'seq-item';
-interface DragItem {
-  index: number;
-}
-
 interface SeqRowProps {
+  /** Stable sortable id (the option value). */
+  id: string;
   index: number;
-  total: number;
   label: string;
   disabled: boolean;
-  onMove: (from: number, to: number) => void;
-  onNudge: (index: number, delta: number) => void;
 }
 
-function SeqRow({ index, total, label, disabled, onMove, onNudge }: SeqRowProps) {
-  const ref = useRef<HTMLLIElement>(null);
-
-  const [{ isDragging }, drag] = useDrag<DragItem, void, { isDragging: boolean }>({
-    type: ITEM_TYPE,
-    item: { index },
-    canDrag: !disabled,
-    collect: (monitor) => ({ isDragging: monitor.isDragging() }),
+/**
+ * One sequence item — a dnd-kit sortable row. The WHOLE row is the drag handle
+ * (drag from anywhere on it), working on desktop AND touch (react-dnd's HTML5
+ * backend was mouse-only), matching the Angular CDK ordered component. The grip
+ * (⠿) is a purely visual "draggable" affordance.
+ */
+function SeqRow({ id, index, label, disabled }: SeqRowProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled,
   });
-
-  const [{ isOver }, drop] = useDrop<DragItem, void, { isOver: boolean }>({
-    accept: ITEM_TYPE,
-    collect: (monitor) => ({ isOver: monitor.isOver() }),
-    hover: (item) => {
-      if (item.index !== index) {
-        onMove(item.index, index);
-        item.index = index;
-      }
-    },
-  });
-
-  drag(drop(ref));
-
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
   return (
     <li
-      ref={ref}
-      className={`${styles.row} ${isDragging ? styles.dragging : ''} ${isOver ? styles.over : ''}`.trim()}
+      ref={setNodeRef}
+      style={style}
+      className={`${styles.row} ${isDragging ? styles.dragging : ''}`.trim()}
+      aria-label={`Item ${index + 1}: drag to reorder`}
+      {...attributes}
+      {...listeners}
     >
       <span className={styles.grip} aria-hidden="true">
         ⠿
       </span>
       <span className={styles.label} dangerouslySetInnerHTML={{ __html: label }} />
-      <span className={styles.controls}>
-        <button
-          type="button"
-          className={styles.nudge}
-          aria-label={`Move item ${index + 1} up`}
-          disabled={disabled || index === 0}
-          onClick={() => onNudge(index, -1)}
-        >
-          ↑
-        </button>
-        <button
-          type="button"
-          className={styles.nudge}
-          aria-label={`Move item ${index + 1} down`}
-          disabled={disabled || index === total - 1}
-          onClick={() => onNudge(index, 1)}
-        >
-          ↓
-        </button>
-      </span>
     </li>
   );
 }
 
 /**
- * SEQ (Sequence) — pure renderer with drag-and-drop reordering (react-dnd) plus
- * keyboard move-up/down controls. Emits { order: [values…] }. Assumes a
- * DndProvider ancestor (provided by the app / tests).
+ * SEQ (Sequence) — pure renderer with dnd-kit drag-and-drop reordering (mouse +
+ * touch + keyboard). Emits { order: [values…] }.
  */
 export function SeqQuestion({
   question,
@@ -126,30 +112,43 @@ export function SeqQuestion({
     onOptionSelected?.({ order: next.map((o) => o.value), timestamp: Date.now() });
   };
 
-  const move = (from: number, to: number) => {
-    if (replayed || to < 0 || to >= items.length) return;
-    const next = [...items];
-    const [moved] = next.splice(from, 1);
-    next.splice(to, 0, moved);
-    commit(next);
+  // dnd-kit sensors: Mouse for desktop (immediate), Touch with a short press
+  // delay so the page can still scroll until a drag is intended, Keyboard for a11y.
+  const sensors = useSensors(
+    useSensor(MouseSensor),
+    useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (replayed || !over || active.id === over.id) return;
+    const from = items.findIndex((o) => String(o.value) === active.id);
+    const to = items.findIndex((o) => String(o.value) === over.id);
+    if (from < 0 || to < 0) return;
+    commit(arrayMove(items, from, to));
   };
+
+  const sortableIds = items.map((o) => String(o.value));
 
   return (
     <div className={styles.seqWrap}>
       <QuestionBody question={question} language={language} mediaCtx={ctx} />
-      <ol className={styles.seq} aria-label="Arrange in order">
-        {items.map((item, index) => (
-          <SeqRow
-            key={String(item.value)}
-            index={index}
-            total={items.length}
-            disabled={replayed}
-            label={resolveLabel(item.label, language, ctx)}
-            onMove={move}
-            onNudge={(i, delta) => move(i, i + delta)}
-          />
-        ))}
-      </ol>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={sortableIds} strategy={verticalListSortingStrategy}>
+          <ol className={styles.seq} aria-label="Arrange in order">
+            {items.map((item, index) => (
+              <SeqRow
+                key={String(item.value)}
+                id={String(item.value)}
+                index={index}
+                disabled={replayed}
+                label={resolveLabel(item.label, language, ctx)}
+              />
+            ))}
+          </ol>
+        </SortableContext>
+      </DndContext>
     </div>
   );
 }


### PR DESCRIPTION
react-dnd's HTML5 backend is mouse-only, so MTF/SEQ drag never worked on touch devices (Angular used @angular/cdk/drag-drop, which is touch-native). Migrate both to @dnd-kit (core + sortable + utilities) with Mouse, Touch (150ms press delay so the page still scrolls) and Keyboard sensors:

- MTF: right column is a sortable list; drag a right image to reorder it so the correct one lands next to each prompt (matches Angular's CDK model).
- SEQ: the whole row is draggable; the grip (⠿) is a visual affordance. The ↑/↓ nudge buttons were removed.

Scoped to MTF/SEQ, each with its own DndContext; REO/other types still use react-dnd (REO is tap-based, matching Angular). typecheck + full suite pass.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules