### PR TITLE
Mobile-app compact layout bump to 0.1.11

### DIFF
--- a/projects/sunbird-quml-player-react/package.json
+++ b/projects/sunbird-quml-player-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-web-component-react",
   "private": true,
-  "version": "0.1.10",
+  "version": "0.1.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/projects/sunbird-quml-player-react/src/App.tsx
+++ b/projects/sunbird-quml-player-react/src/App.tsx
@@ -24,10 +24,13 @@ function resolveConfig(): PlayerConfig {
       context: { uid: 'dev-user', sid: 'dev-session', channel: 'dev', host: '' },
       // Only set language when ?lang is present; otherwise let the language
       // precedence (localStorage['app-language'] → 'en') apply.
-      config: { language: params.get('lang') ?? undefined, maxAttempts: 3 },
+      config: { language: params.get('lang') ?? undefined },
       // API mode: only an identifier, no embedded sections. Online asset hosts
       // come from each media[].baseUrl in the backend response (Angular parity).
       data: { identifier },
+      // maxAttempts is host/backend data (Angular parity: playerConfig.metadata),
+      // not a player UI setting.
+      metadata: { maxAttempts: 3 },
     };
   }
 

--- a/projects/sunbird-quml-player-react/src/components/Hint/Hint.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/Hint/Hint.module.scss
@@ -6,6 +6,10 @@
   flex-direction: column;
   gap: v.$space-4;
   margin-top: v.$space-8;
+
+  @include m.short {
+    margin-top: v.$space-3;
+  }
 }
 
 .actions {

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.max-attempts.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.max-attempts.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import type { PlayerConfig } from '../../types';
+
+// Angular parity (main-player.component.ts:249,253,483-485) — maxAttempts is
+// host/backend data under `playerConfig.metadata`, not `config`.
+const baseData = {
+  showTimer: false,
+  sections: [
+    {
+      identifier: 's1',
+      name: 'Section 1',
+      timeLimits: { questionSet: { max: 0, min: 0 } },
+      children: [
+        {
+          identifier: 'q1',
+          body: '<p>Q1</p>',
+          primaryCategory: 'Multiple Choice Question',
+          interactions: { response1: { options: [{ value: 0, label: 'Apple' }, { value: 1, label: 'Banana' }] } },
+          responseDeclaration: {
+            response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 0 } },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const enterAssessment = () => {
+  fireEvent.click(screen.getByRole('button', { name: /start assessment/i }));
+  fireEvent.click(screen.getByRole('button', { name: /start section/i }));
+};
+
+const submitAssessment = () => {
+  fireEvent.click(screen.getAllByRole('radio')[0]); // answer correctly
+  fireEvent.click(screen.getAllByRole('button', { name: /^submit$/i })[0]);
+  const dialog = screen.getByRole('dialog');
+  fireEvent.click(within(dialog).getByRole('button', { name: /^submit$/i }));
+};
+
+describe('MainPlayer — max attempts (Angular parity)', () => {
+  it('hides Retake on Results once this attempt is the last one allowed', () => {
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: { maxAttempts: 1 },
+      data: baseData,
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+    enterAssessment();
+    submitAssessment();
+    expect(screen.getByRole('heading', { name: /your results/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retake/i })).not.toBeInTheDocument();
+  });
+
+  it('keeps Retake when attempts remain', () => {
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: { maxAttempts: 3 },
+      data: baseData,
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+    enterAssessment();
+    submitAssessment();
+    expect(screen.getByRole('button', { name: /retake/i })).toBeInTheDocument();
+  });
+
+  it('emits an exdata isLastAttempt event when the final attempt starts', () => {
+    const onPlayerEvent = vi.fn();
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: { maxAttempts: 1 },
+      data: baseData,
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} onPlayerEvent={onPlayerEvent} />
+      </QumlProvider>,
+    );
+    expect(onPlayerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eid: 'exdata',
+        edata: expect.objectContaining({
+          currentattempt: 1,
+          isLastAttempt: true,
+          maxLimitExceeded: false,
+        }),
+      }),
+    );
+  });
+
+  it('emits an exdata maxLimitExceeded event when the last attempt is submitted', () => {
+    const onPlayerEvent = vi.fn();
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      metadata: { maxAttempts: 1 },
+      data: baseData,
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} onPlayerEvent={onPlayerEvent} />
+      </QumlProvider>,
+    );
+    onPlayerEvent.mockClear();
+    enterAssessment();
+    submitAssessment();
+    expect(onPlayerEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eid: 'exdata',
+        edata: expect.objectContaining({
+          currentattempt: 1,
+          isLastAttempt: false,
+          maxLimitExceeded: true,
+        }),
+      }),
+    );
+  });
+
+  it('does not restrict Retake when maxAttempts is not sent (unlimited)', () => {
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      data: baseData,
+    };
+    render(
+      <QumlProvider playerConfig={cfg}>
+        <MainPlayer playerConfig={cfg} />
+      </QumlProvider>,
+    );
+    enterAssessment();
+    submitAssessment();
+    expect(screen.getByRole('button', { name: /retake/i })).toBeInTheDocument();
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.timer-showtimer-parity.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.timer-showtimer-parity.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
+import { QumlProvider } from '../../context/QumlContext';
+import { MainPlayer } from './MainPlayer';
+import type { PlayerConfig } from '../../types';
+
+// Angular parity (section-player.component.ts:232-235, main-player.component.ts
+// :172,257,488-493) — `showTimer` only gates the LIVE widget's visibility; it
+// has no bearing on whether the clock is tracked, whether a time limit is
+// enforced, or whether the results screen can report duration. These configs
+// all set `showTimer: false` (or omit it) while still exercising the clock.
+
+const mcq = (id: string) => ({
+  identifier: id,
+  body: `<p>${id}</p>`,
+  primaryCategory: 'Multiple Choice Question',
+  interactions: { response1: { options: [{ value: 0, label: 'Apple' }, { value: 1, label: 'Banana' }] } },
+  responseDeclaration: {
+    response1: { cardinality: 'single', type: 'integer', correctResponse: { value: 0 } },
+  },
+});
+
+const enterAssessment = () => {
+  fireEvent.click(screen.getByRole('button', { name: /start assessment/i }));
+  fireEvent.click(screen.getByRole('button', { name: /start section/i }));
+};
+
+describe('MainPlayer — showTimer/summaryType parity (Angular)', () => {
+  it('auto-submits at time-limit expiry even when showTimer is false (hidden limit is still enforced)', () => {
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      data: {
+        showTimer: false,
+        timeLimits: { questionSet: { max: 2, min: 0 } },
+        sections: [{ identifier: 's1', name: 'Section 1', children: [mcq('q1')] }],
+      },
+    };
+    vi.useFakeTimers();
+    try {
+      render(
+        <QumlProvider playerConfig={cfg}>
+          <MainPlayer playerConfig={cfg} />
+        </QumlProvider>,
+      );
+      enterAssessment();
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+      // No visible countdown — showTimer is false.
+      expect(screen.queryByRole('timer')).not.toBeInTheDocument();
+      // Past the 2s limit → auto-submit, no confirmation needed.
+      act(() => vi.advanceTimersByTime(2100));
+      expect(screen.getByRole('heading', { name: /your results/i })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('reports duration on Results when showTimer is false and summaryType allows it', () => {
+    const cfg: PlayerConfig = {
+      context: {},
+      config: { language: 'en' },
+      data: {
+        showTimer: false,
+        summaryType: 'Score and Duration',
+        sections: [{ identifier: 's1', name: 'Section 1', children: [mcq('q1')] }],
+      },
+    };
+    vi.useFakeTimers();
+    try {
+      render(
+        <QumlProvider playerConfig={cfg}>
+          <MainPlayer playerConfig={cfg} />
+        </QumlProvider>,
+      );
+      enterAssessment();
+      act(() => vi.advanceTimersByTime(3000)); // 3s elapsed, count-up mode (no time limit)
+      fireEvent.click(screen.getAllByRole('radio')[0]);
+      fireEvent.click(screen.getAllByRole('button', { name: /^submit$/i })[0]);
+      const dialog = screen.getByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: /^submit$/i }));
+      expect(screen.getByRole('heading', { name: /your results/i })).toBeInTheDocument();
+      expect(screen.getByText(/time taken/i)).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -78,6 +78,12 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const [timeRemaining, setTimeRemaining] = useState<number | null>(null);
   // One-shot guard for the showStartPage:'No' auto-advance past the overview.
   const autoStartedRef = useRef(false);
+  // True once the assessment has been entered at least once this attempt — the
+  // brand-click (onBrandClick) returns to Overview WITHOUT resetting progress
+  // or the clock, so the CTA there must read "Resume", not "Start" (Retake is
+  // the only path that clears this, since it's the only path that actually
+  // restarts from zero).
+  const [hasStarted, setHasStarted] = useState(false);
 
   // Section intros can be disabled via config (spec §6.0).
   const sectionIntrosEnabled =
@@ -93,6 +99,16 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const requiresSubmitConfirmation =
     metadata.requiresSubmit !== 'No' && metadata.requiresSubmit !== false;
 
+  // Angular parity (main-player.component.ts:249) — host/backend data under
+  // `playerConfig.metadata`, not the player's own `config` (UI-only settings).
+  // Read once here since it's needed beyond the overview (Retake gating below
+  // + the exdata event effect further down).
+  const maxAttempts =
+    (playerConfig?.metadata as { maxAttempts?: number } | undefined)?.maxAttempts ?? null;
+  // Angular parity (main-player.component.ts:253 `showReplay`) — once this
+  // attempt IS the last allowed one, Retake must not offer another.
+  const canRetake = maxAttempts == null || state.attemptNumber < maxAttempts;
+
   // Initialize config + normalized sections.
   //
   // Two data sources, decided by shape (never both):
@@ -105,6 +121,17 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   const initializeFromConfig = useCallback(async () => {
     if (!playerConfig) return;
     setPlayerConfig(playerConfig);
+
+    // Angular parity (main-player.component.ts:250) — the host tracks attempts
+    // used across PAST sessions and passes the count back; this session's
+    // attempt number is one past that. Retake's own `setAttempt(nextAttempt)`
+    // (called right after this function) overrides this for the in-session
+    // case, so this only matters on a fresh mount.
+    const seedAttempt = (playerConfig.metadata as { currentAttempt?: number } | undefined)
+      ?.currentAttempt;
+    if (typeof seedAttempt === 'number') {
+      setAttempt(seedAttempt + 1);
+    }
 
     const data = (playerConfig.data as Record<string, unknown> | undefined) ?? {};
     // Host-contract compatibility: the Sunbird editor/portal follow the Angular
@@ -181,7 +208,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
         err instanceof QumlApiError ? err.message : 'Failed to load the assessment.';
       setError(message);
     }
-  }, [playerConfig, setPlayerConfig, setSections, setLoading, setError]);
+  }, [playerConfig, setPlayerConfig, setSections, setLoading, setError, setAttempt]);
 
   useEffect(() => {
     initializeFromConfig();
@@ -223,7 +250,6 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     );
     const timeLimits = (data.timeLimits as { questionSet?: { max?: number } } | undefined)
       ?.questionSet;
-    const cfg = (playerConfig?.config as { maxAttempts?: number } | undefined) ?? {};
     return {
       title: readI18n(data.name as I18nValue | undefined, language) || t(language, 'ASSESSMENT_OVERVIEW'),
       description: readI18n(data.description as I18nValue | undefined, language) || undefined,
@@ -236,9 +262,37 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
       // false → no timer at all; the count-up fallback also requires it.
       showTimer: data.showTimer === true || data.showTimer === 'true',
       maxScore,
-      attemptsLeft: Math.max(0, (cfg.maxAttempts ?? 3) - (state.attemptNumber - 1)),
+      // Absent (not sent by the backend) → unlimited attempts: null, distinct
+      // from an explicit 0/low maxAttempts, so StartPage can show "No Limit"
+      // instead of a fabricated default.
+      attemptsLeft:
+        maxAttempts == null ? null : Math.max(0, maxAttempts - (state.attemptNumber - 1)),
     };
-  }, [metadata, playerConfig, state.sections, state.attemptNumber, language]);
+  }, [metadata, maxAttempts, state.sections, state.attemptNumber, language]);
+
+  // Angular parity (main-player.component.ts:258,276-282,415-417 emitMaxAttemptEvents
+  // + replayContent) — tell the host when the CURRENT attempt is the last one
+  // allowed, or already past the limit (the host decides how to react, e.g. its
+  // own "no attempts left" messaging). Keyed on attemptNumber, so this covers
+  // BOTH Angular call sites (component init AND Retake) in one place — Retake
+  // changes attemptNumber, which re-fires this effect with the new value.
+  useEffect(() => {
+    if (maxAttempts == null) return;
+    const current = state.attemptNumber;
+    if (current < maxAttempts) return;
+    onPlayerEvent?.({
+      eid: 'exdata',
+      edata: {
+        type: 'exdata',
+        currentattempt: current,
+        isLastAttempt: current === maxAttempts,
+        maxLimitExceeded: current > maxAttempts,
+      },
+    });
+    // onPlayerEvent identity isn't guaranteed stable across host re-renders;
+    // only the attempt boundary itself should re-trigger this.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.attemptNumber, maxAttempts]);
 
   // Stages where the exam clock runs: once started, it keeps ticking through
   // section intros (switching sections doesn't stop the clock). It PAUSES on
@@ -321,6 +375,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setCurrentSection(0);
     setCurrentQuestion(0);
     beginAssessmentTimer();
+    setHasStarted(true);
     setStage(sectionIntrosEnabled ? 'sectionIntro' : 'assessment');
   };
 
@@ -334,6 +389,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setCurrentSection(index);
     setCurrentQuestion(0);
     beginAssessmentTimer();
+    setHasStarted(true);
     setStage(sectionIntrosEnabled ? 'sectionIntro' : 'assessment');
   };
 
@@ -348,6 +404,19 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setSubmitDialog(false);
     setStage('results');
     onPlayerEvent?.({ type: 'quizEnd', summary });
+    // Angular parity (main-player.component.ts:483-485 raiseEndEvent) — flag
+    // to the host that this attempt, now finished, was the last one allowed.
+    if (maxAttempts != null && state.attemptNumber >= maxAttempts) {
+      onPlayerEvent?.({
+        eid: 'exdata',
+        edata: {
+          type: 'exdata',
+          currentattempt: state.attemptNumber,
+          isLastAttempt: false,
+          maxLimitExceeded: true,
+        },
+      });
+    }
   };
 
   const handleCancelSubmit = () => setSubmitDialog(false);
@@ -368,6 +437,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setTimeRemaining(null);
     setTimeElapsed(0);
     setSubmitDialog(false);
+    setHasStarted(false);
     setStage('overview');
   };
 
@@ -406,6 +476,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     setCurrentSection(0);
     setCurrentQuestion(0);
     beginAssessmentTimer();
+    setHasStarted(true);
     setStage('assessment');
     // Guarded by the ref; the setters/timer are stable enough here.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -454,6 +525,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
         totalSections={overview.totalSections}
         timeLimit={overview.timeLimit}
         attemptsLeft={overview.attemptsLeft}
+        hasStarted={hasStarted}
         onStart={handleStart}
         onSectionSelect={handleSectionSelectFromOverview}
         language={language}
@@ -475,7 +547,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
         summary={summary}
         timeTaken={timeTaken}
         onReviewAll={handleReviewAll}
-        onRetake={handleRetake}
+        onRetake={canRetake ? handleRetake : undefined}
         language={language}
       />
     );
@@ -501,6 +573,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
           sectionIndex={state.currentSectionIndex}
           totalSections={state.sections.length}
           onBegin={handleBegin}
+          onPrevious={() => setStage('overview')}
           language={language}
         />
       ) : (

--- a/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/MainPlayer/MainPlayer.tsx
@@ -261,6 +261,11 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
       // the timer is shown ONLY when the content opts in via `showTimer`. Absent /
       // false → no timer at all; the count-up fallback also requires it.
       showTimer: data.showTimer === true || data.showTimer === 'true',
+      // Angular parity (main-player.component.ts:488-524) — gates score/duration
+      // visibility on the results screen. 'Complete'→score as a fraction,
+      // 'Duration'→score hidden, 'Score'→duration hidden, 'Score and Duration'/
+      // absent→both shown as plain values.
+      summaryType: data.summaryType as string | undefined,
       maxScore,
       // Absent (not sent by the backend) → unlimited attempts: null, distinct
       // from an explicit 0/low maxAttempts, so StartPage can show "No Limit"
@@ -322,13 +327,25 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
   }, [isClockRunning]);
 
   // Count-up elapsed timer (Angular header showCountUp parity): when the
-  // assessment has NO time limit, the header shows time spent instead of a
+  // assessment has NO time limit, this tracks time spent instead of a
   // countdown. Same run/pause semantics as the countdown, anchored to a
   // timestamp so it never drifts.
+  //
+  // Angular parity — NOT gated on `showTimer`: showTimer only controls whether
+  // the live widget is *visible* (main-player.component.ts:172, section-player
+  // .component.ts:58,235 — fed straight into the timer display component,
+  // nothing else). Duration tracking itself (main-player.component.ts:257
+  // initialTime, :488-493 setDurationSpent) and time-limit enforcement
+  // (section-player.component.ts:232-233) both run unconditionally in
+  // Angular. Previously this effect also required `overview.showTimer`, so a
+  // hidden timer (showTimer:false/unset) meant elapsed time was never tracked
+  // at all — the results screen had nothing to show regardless of
+  // `summaryType`. The header's OWN display of this value is still gated on
+  // `showTimer` separately, further down — only the tracking moved.
   const [timeElapsed, setTimeElapsed] = useState(0);
   const elapsedAnchorRef = useRef<number | null>(null);
   useEffect(() => {
-    if (!isClockRunning || overview.timeLimit > 0 || !overview.showTimer) return;
+    if (!isClockRunning || overview.timeLimit > 0) return;
     elapsedAnchorRef.current = Date.now() - timeElapsed * 1000;
     const id = setInterval(() => {
       setTimeElapsed(Math.floor((Date.now() - elapsedAnchorRef.current!) / 1000));
@@ -337,7 +354,7 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     // Re-anchor only when the clock starts/stops; timeElapsed is read once as
     // the resume point.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isClockRunning, overview.timeLimit, overview.showTimer]);
+  }, [isClockRunning, overview.timeLimit]);
 
   // Time up → auto-submit straight to results (no confirmation dialog).
   useEffect(() => {
@@ -364,9 +381,11 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
 
   // ── Flow transitions ───────────────────────────────────────────────────────
   const beginAssessmentTimer = () => {
-    // No countdown (and therefore no auto-submit on expiry) unless the content
-    // opts into the timer — Angular's header never starts the interval otherwise.
-    if (overview.showTimer && timeRemaining == null && overview.timeLimit > 0) {
+    // Angular parity — NOT gated on `showTimer` (see the count-up effect's
+    // comment above for the citations): a real `timeLimit` always counts down
+    // and enforces auto-submit-at-zero, whether or not the content shows the
+    // live widget. `showTimer` only gates the header's own display, below.
+    if (timeRemaining == null && overview.timeLimit > 0) {
       setTimeRemaining(overview.timeLimit);
     }
   };
@@ -533,19 +552,18 @@ export function MainPlayer({ playerConfig, onPlayerEvent }: MainPlayerProps) {
     );
   } else if (stage === 'results') {
     // Total time spent: countdown mode → limit minus what was left; count-up
-    // mode → the elapsed counter (both tick only during the assessment stage).
-    // When the timer is suppressed (showTimer off) neither clock runs, so there
-    // is no meaningful elapsed value — pass null so Results omits "Time Taken"
-    // rather than showing a misleading 0:00.
-    const timeTaken = !overview.showTimer
-      ? null
-      : overview.timeLimit > 0
-        ? overview.timeLimit - (timeRemaining ?? overview.timeLimit)
-        : timeElapsed;
+    // mode → the elapsed counter (both tick unconditionally once the
+    // assessment stage starts — Angular parity, see the count-up effect's
+    // comment above: NOT gated on `showTimer`, which only controls the live
+    // widget's visibility, not whether time is tracked). `summaryType:'Score'`
+    // hides duration on-screen — that gating lives in ResultsScreen, not here.
+    const timeTaken =
+      overview.timeLimit > 0 ? overview.timeLimit - (timeRemaining ?? overview.timeLimit) : timeElapsed;
     content = (
       <ResultsScreen
         summary={summary}
         timeTaken={timeTaken}
+        summaryType={overview.summaryType}
         onReviewAll={handleReviewAll}
         onRetake={canRetake ? handleRetake : undefined}
         language={language}

--- a/projects/sunbird-quml-player-react/src/components/QuestionCard/QuestionCard.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/QuestionCard/QuestionCard.module.scss
@@ -12,13 +12,22 @@
   @include m.mobile {
     padding: v.$space-5;
   }
+
+  @include m.short {
+    padding: v.$space-4;
+  }
 }
 
 .meta {
   display: flex;
+  align-items: center;
   flex-wrap: wrap;
   gap: v.$space-2;
   margin-bottom: v.$space-5;
+
+  @include m.short {
+    margin-bottom: v.$space-3;
+  }
 }
 
 .category,
@@ -43,6 +52,23 @@
   color: v.$g600;
 }
 
+// Mobile-app only — replaces the top nav bar's counter, which is hidden in
+// compact mode (see SectionPlayer.module.scss .counter). Desktop/tablet/
+// portal/editor keep the top-bar counter and never show this.
+.progress {
+  display: none;
+  font-family: v.$ff-base;
+  font-size: v.$text-xs;
+  font-weight: v.$fw-semibold;
+  color: v.$g400;
+  font-variant-numeric: tabular-nums;
+
+  @include m.compact {
+    display: inline-flex;
+    align-items: center;
+  }
+}
+
 .body {
   font-family: v.$ff-question;
 }
@@ -51,4 +77,9 @@
   margin-top: v.$space-6;
   padding-top: v.$space-5;
   border-top: 1px solid v.$gray-200;
+
+  @include m.short {
+    margin-top: v.$space-3;
+    padding-top: v.$space-3;
+  }
 }

--- a/projects/sunbird-quml-player-react/src/components/QuestionCard/QuestionCard.tsx
+++ b/projects/sunbird-quml-player-react/src/components/QuestionCard/QuestionCard.tsx
@@ -13,13 +13,15 @@ export interface QuestionCardProps {
   question: Question;
   children: ReactNode;
   meta?: { category?: string; difficulty?: string };
+  /** Position within the section, e.g. { current: 2, total: 4 } → "2/4". */
+  progress?: { current: number; total: number };
   footer?: ReactNode;
 }
 
-export function QuestionCard({ question, children, meta, footer }: QuestionCardProps) {
+export function QuestionCard({ question, children, meta, progress, footer }: QuestionCardProps) {
   const category = meta?.category ?? question.primaryCategory;
   const difficulty = meta?.difficulty;
-  const hasMeta = Boolean(category || difficulty);
+  const hasMeta = Boolean(category || difficulty || progress);
 
   return (
     <article className={styles.card}>
@@ -27,6 +29,11 @@ export function QuestionCard({ question, children, meta, footer }: QuestionCardP
         <div className={styles.meta}>
           {category && <span className={styles.category}>{category}</span>}
           {difficulty && <span className={styles.difficulty}>{difficulty}</span>}
+          {progress && (
+            <span className={styles.progress}>
+              {progress.current}/{progress.total}
+            </span>
+          )}
         </div>
       )}
 

--- a/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.module.scss
@@ -8,6 +8,10 @@
   padding: v.$space-10 v.$space-6;
   background: v.$cream-bg;
   font-family: v.$ff-base;
+
+  @include m.short {
+    padding: v.$space-3;
+  }
 }
 
 .card {
@@ -22,6 +26,10 @@
   @include m.mobile {
     padding: v.$space-6 v.$space-5;
   }
+
+  @include m.short {
+    padding: v.$space-4;
+  }
 }
 
 .title {
@@ -29,6 +37,11 @@
   font-size: v.$text-2xl;
   font-weight: v.$fw-bold;
   color: v.$g900;
+
+  @include m.short {
+    margin-bottom: v.$space-3;
+    font-size: v.$text-xl;
+  }
 }
 
 .timeTaken {
@@ -36,6 +49,10 @@
   font-size: v.$text-sm;
   color: v.$gray-500;
   font-variant-numeric: tabular-nums;
+
+  @include m.short {
+    margin-top: v.$space-2;
+  }
 }
 
 .actions {
@@ -43,6 +60,10 @@
   justify-content: center;
   gap: v.$space-3;
   margin-top: v.$space-8;
+
+  @include m.short {
+    margin-top: v.$space-3;
+  }
 }
 
 .reviewBtn {
@@ -55,6 +76,10 @@
   &:hover:not(:disabled) {
     background: v.$g800;
   }
+
+  @include m.short {
+    padding: v.$space-2 v.$space-4;
+  }
 }
 
 .retakeBtn {
@@ -64,6 +89,10 @@
   background: transparent;
   color: v.$g700;
   border: 1.5px solid v.$gray-300;
+
+  @include m.short {
+    padding: v.$space-2 v.$space-4;
+  }
 
   &:hover:not(:disabled) {
     border-color: v.$g400;

--- a/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.test.tsx
@@ -31,4 +31,10 @@ describe('ResultsScreen', () => {
     expect(onReviewAll).toHaveBeenCalledTimes(1);
     expect(onRetake).toHaveBeenCalledTimes(1);
   });
+
+  it('hides Retake when omitted (attempts exhausted — Angular parity: showReplay=false)', () => {
+    render(<ResultsScreen summary={summary} onReviewAll={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /retake/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /review all/i })).toBeInTheDocument();
+  });
 });

--- a/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.test.tsx
@@ -37,4 +37,61 @@ describe('ResultsScreen', () => {
     expect(screen.queryByRole('button', { name: /retake/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /review all/i })).toBeInTheDocument();
   });
+
+  // Angular parity (main-player.component.ts:488-524) — summaryType gates
+  // score/duration visibility. The correct/incorrect/partial/skipped breakdown
+  // has no Angular equivalent and is intentionally always shown regardless.
+  describe('summaryType (Angular parity)', () => {
+    it('"Complete" shows the score as a fraction', () => {
+      render(
+        <ResultsScreen summary={summary} summaryType="Complete" onReviewAll={vi.fn()} />,
+      );
+      expect(screen.getByText('7 / 10')).toBeInTheDocument();
+    });
+
+    it('"Score" shows a plain score and hides duration', () => {
+      render(
+        <ResultsScreen
+          summary={summary}
+          summaryType="Score"
+          timeTaken={204}
+          onReviewAll={vi.fn()}
+        />,
+      );
+      expect(screen.getByText('7')).toBeInTheDocument();
+      expect(screen.queryByText(/time taken/i)).not.toBeInTheDocument();
+    });
+
+    it('"Duration" hides the score entirely', () => {
+      render(
+        <ResultsScreen
+          summary={summary}
+          summaryType="Duration"
+          timeTaken={204}
+          onReviewAll={vi.fn()}
+        />,
+      );
+      expect(screen.queryByText(/^score/i)).not.toBeInTheDocument();
+      expect(screen.getByText('3:24')).toBeInTheDocument();
+    });
+
+    it('"Score and Duration" (and absent) shows a plain score and duration', () => {
+      render(
+        <ResultsScreen
+          summary={summary}
+          summaryType="Score and Duration"
+          timeTaken={204}
+          onReviewAll={vi.fn()}
+        />,
+      );
+      expect(screen.getByText('7')).toBeInTheDocument();
+      expect(screen.getByText('3:24')).toBeInTheDocument();
+    });
+
+    it('always shows the correct/incorrect/partial/skipped breakdown regardless of summaryType', () => {
+      render(<ResultsScreen summary={summary} summaryType="Duration" onReviewAll={vi.fn()} />);
+      expect(screen.getByRole('region', { name: /quiz summary/i })).toBeInTheDocument();
+      expect(screen.getByText('6')).toBeInTheDocument(); // correct count
+    });
+  });
 });

--- a/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.tsx
+++ b/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.tsx
@@ -21,7 +21,8 @@ export interface ResultsScreenProps {
   /** Total seconds spent answering (shell timer); null/omitted hides the line. */
   timeTaken?: number | null;
   onReviewAll: () => void;
-  onRetake: () => void;
+  /** Omit to hide the Retake CTA (Angular parity: `showReplay=false` once attempts are exhausted). */
+  onRetake?: () => void;
   language?: string;
 }
 
@@ -52,6 +53,7 @@ export function ResultsScreen({
           partial={summary.partial}
           skipped={summary.skipped}
           totalScore={totalScore}
+          language={language}
         />
 
         {timeTaken != null && (
@@ -64,9 +66,11 @@ export function ResultsScreen({
           <button type="button" className={styles.reviewBtn} onClick={onReviewAll}>
             {t(language, 'REVIEW_ALL')}
           </button>
-          <button type="button" className={styles.retakeBtn} onClick={onRetake}>
-            {t(language, 'RETAKE')}
-          </button>
+          {onRetake && (
+            <button type="button" className={styles.retakeBtn} onClick={onRetake}>
+              {t(language, 'RETAKE')}
+            </button>
+          )}
         </div>
       </div>
     </section>

--- a/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.tsx
+++ b/projects/sunbird-quml-player-react/src/components/ResultsScreen/ResultsScreen.tsx
@@ -20,6 +20,14 @@ export interface ResultsScreenProps {
   };
   /** Total seconds spent answering (shell timer); null/omitted hides the line. */
   timeTaken?: number | null;
+  /**
+   * Angular parity (main-player.component.ts:488-524) — 'Complete' shows the
+   * score as a `score/max` fraction; 'Duration' hides the score entirely;
+   * anything else (including absent) shows a plain score number. Does NOT
+   * affect the correct/incorrect/partial/skipped breakdown below, which has
+   * no Angular equivalent and is intentionally always shown.
+   */
+  summaryType?: string;
   onReviewAll: () => void;
   /** Omit to hide the Retake CTA (Angular parity: `showReplay=false` once attempts are exhausted). */
   onRetake?: () => void;
@@ -36,11 +44,16 @@ function formatMmSs(seconds: number): string {
 export function ResultsScreen({
   summary,
   timeTaken = null,
+  summaryType,
   onReviewAll,
   onRetake,
   language = 'en',
 }: ResultsScreenProps) {
   const { totalScore } = summary;
+  const showScore = summaryType !== 'Duration';
+  const showDuration = summaryType !== 'Score';
+  const scoreLabel =
+    summaryType === 'Complete' && summary.maxScore ? `${totalScore} / ${summary.maxScore}` : undefined;
 
   return (
     <section className={styles.results} aria-label={t(language, 'YOUR_RESULTS')}>
@@ -53,10 +66,12 @@ export function ResultsScreen({
           partial={summary.partial}
           skipped={summary.skipped}
           totalScore={totalScore}
+          showScore={showScore}
+          scoreLabel={scoreLabel}
           language={language}
         />
 
-        {timeTaken != null && (
+        {timeTaken != null && showDuration && (
           <p className={styles.timeTaken}>
             {t(language, 'TIME_TAKEN')}: <strong>{formatMmSs(timeTaken)}</strong>
           </p>

--- a/projects/sunbird-quml-player-react/src/components/ReviewScreen/ReviewScreen.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/ReviewScreen/ReviewScreen.module.scss
@@ -59,7 +59,11 @@
   border-inline-end: 1px solid v.$gray-200;
   background: v.$ivory;
 
-  @include m.mobile {
+  // Mobile-app only — was width-only (`m.mobile`), so a landscape phone (short
+  // height, but wide enough to miss that width tier) still showed the full
+  // section list with its per-section question counts, same crowding problem
+  // as everything else we've compacted. `m.compact` covers both orientations.
+  @include m.compact {
     display: none;
   }
 }
@@ -71,6 +75,8 @@
   min-width: 0;
   overflow-y: auto;
   padding: v.$space-8 v.$space-12;
+  // Positioning context for .navBtn in compact mode (see below).
+  position: relative;
 
   @include m.tablet {
     padding: v.$space-6 v.$space-6;
@@ -78,6 +84,17 @@
 
   @include m.mobile {
     padding: v.$space-5 v.$space-4;
+  }
+
+  // Mobile-app only (see SectionPlayer.module.scss .content for the same
+  // treatment) — widen the inline gutter so the floating Prev/Next buttons
+  // land beside the question, not over it. Also shrink the top padding: with
+  // the counter hidden and the buttons floated out of flow, `.navBar` collapses
+  // to ~0 height, so the old top padding (sized for a full nav row) just left
+  // a tall gap above the verdict pill and card.
+  @include m.compact {
+    padding-block: v.$space-3 v.$space-4;
+    padding-inline: 2.75rem;
   }
 }
 
@@ -88,6 +105,10 @@
   border-radius: v.$r-pill;
   font-size: v.$text-sm;
   font-weight: v.$fw-semibold;
+
+  @include m.compact {
+    margin-bottom: v.$space-3;
+  }
 }
 
 .correct {
@@ -121,6 +142,13 @@
   justify-content: space-between;
   gap: v.$space-4;
   margin-bottom: v.$space-6;
+
+  // Mobile-app only: the counter is hidden and the buttons float out of flow
+  // (see .counter/.navBtn below), so this row has no in-flow content left —
+  // drop the margin it no longer needs to reserve.
+  @include m.compact {
+    margin-bottom: 0;
+  }
 }
 
 .counter {
@@ -128,6 +156,12 @@
   font-weight: v.$fw-medium;
   color: v.$g600;
   font-variant-numeric: tabular-nums;
+
+  // Mobile-app only: replaced by QuestionCard's progress badge next to the
+  // question-type tag (same treatment as SectionPlayer.module.scss .counter).
+  @include m.compact {
+    display: none;
+  }
 }
 
 .navBtn {
@@ -143,10 +177,48 @@
     color: v.$g900;
     background: v.$cream-bg;
   }
+
+  // Mobile-app only — float beside the question, vertically centered on the
+  // full main-column height (`.main`, not `.navBar`), icon-only circle. Same
+  // treatment as SectionPlayer.module.scss .navBtn.
+  @include m.compact {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 5;
+    min-width: 0;
+    min-height: 0;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border-radius: v.$r-pill;
+    background: v.$white;
+    box-shadow: v.$shadow-sm;
+
+    &:hover:not(:disabled) {
+      transform: translateY(-50%);
+    }
+  }
+}
+
+.navPrev {
+  @include m.compact {
+    left: v.$space-1;
+  }
+}
+
+.navNext {
+  @include m.compact {
+    right: v.$space-1;
+  }
 }
 
 .navLabel {
   @include m.mobile {
+    display: none;
+  }
+
+  @include m.compact {
     display: none;
   }
 }

--- a/projects/sunbird-quml-player-react/src/components/ReviewScreen/ReviewScreen.tsx
+++ b/projects/sunbird-quml-player-react/src/components/ReviewScreen/ReviewScreen.tsx
@@ -143,7 +143,7 @@ export function ReviewScreen({
           <div className={styles.navBar}>
             <button
               type="button"
-              className={styles.navBtn}
+              className={`${styles.navBtn} ${styles.navPrev}`}
               onClick={() => setIndex((i) => Math.max(0, i - 1))}
               disabled={isFirst}
               aria-label={t(language, 'PREVIOUS')}
@@ -158,7 +158,7 @@ export function ReviewScreen({
 
             <button
               type="button"
-              className={styles.navBtn}
+              className={`${styles.navBtn} ${styles.navNext}`}
               onClick={() => setIndex((i) => Math.min(questions.length - 1, i + 1))}
               disabled={isLast}
               aria-label={t(language, 'NEXT')}
@@ -172,7 +172,11 @@ export function ReviewScreen({
             {t(language, LABEL_KEY[kind])}
           </div>
 
-          <QuestionCard question={question} meta={{ category: question.primaryCategory }}>
+          <QuestionCard
+            question={question}
+            meta={{ category: question.primaryCategory }}
+            progress={{ current: index + 1, total: questions.length }}
+          >
             <QuestionRenderer
               key={question.identifier}
               question={question}

--- a/projects/sunbird-quml-player-react/src/components/Scoreboard/Scoreboard.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/Scoreboard/Scoreboard.module.scss
@@ -11,6 +11,10 @@
   box-shadow: v.$shadow-card;
   text-align: center;
   font-family: v.$ff-base;
+
+  @include m.short {
+    padding: v.$space-4 v.$space-3;
+  }
 }
 
 .heading {
@@ -18,6 +22,11 @@
   font-size: v.$text-xl;
   font-weight: v.$fw-bold;
   color: v.$dark;
+
+  @include m.short {
+    margin-bottom: v.$space-3;
+    font-size: v.$text-md;
+  }
 }
 
 .stats {
@@ -31,6 +40,10 @@
   @include m.mobile {
     flex-wrap: wrap;
   }
+
+  @include m.short {
+    margin-bottom: v.$space-3;
+  }
 }
 
 .stat {
@@ -38,6 +51,10 @@
   min-width: 70px;
   padding: v.$space-3 v.$space-2;
   background: v.$white;
+
+  @include m.short {
+    padding: v.$space-2;
+  }
 }
 
 .statValue {
@@ -74,6 +91,10 @@
   margin: 0 0 v.$space-6;
   font-size: v.$text-md;
   color: v.$g700;
+
+  @include m.short {
+    margin-bottom: v.$space-3;
+  }
 }
 
 .submit {

--- a/projects/sunbird-quml-player-react/src/components/Scoreboard/Scoreboard.tsx
+++ b/projects/sunbird-quml-player-react/src/components/Scoreboard/Scoreboard.tsx
@@ -16,6 +16,10 @@ interface ScoreboardProps {
   totalScore?: number;
   onSubmit?: () => void;
   language?: string;
+  /** Angular parity (summaryType:'Duration') — hide the score line entirely. Default true. */
+  showScore?: boolean;
+  /** Override the displayed score value (e.g. "7 / 10" for summaryType:'Complete'). Defaults to the plain `totalScore`. */
+  scoreLabel?: string;
 }
 
 export function Scoreboard({
@@ -26,6 +30,8 @@ export function Scoreboard({
   totalScore = 0,
   onSubmit,
   language = 'en',
+  showScore = true,
+  scoreLabel,
 }: ScoreboardProps) {
   const stats: Array<{ key: string; label: string; value: number; variant: string }> = [
     { key: 'correct', label: t(language, 'CORRECT'), value: correct, variant: styles.correct },
@@ -47,9 +53,11 @@ export function Scoreboard({
         ))}
       </dl>
 
-      <p className={styles.score}>
-        {t(language, 'SCORE')}: <strong>{totalScore}</strong>
-      </p>
+      {showScore && (
+        <p className={styles.score}>
+          {t(language, 'SCORE')}: <strong>{scoreLabel ?? totalScore}</strong>
+        </p>
+      )}
 
       {onSubmit && (
         <button type="button" className={styles.submit} onClick={onSubmit}>

--- a/projects/sunbird-quml-player-react/src/components/Scoreboard/Scoreboard.tsx
+++ b/projects/sunbird-quml-player-react/src/components/Scoreboard/Scoreboard.tsx
@@ -1,3 +1,4 @@
+import { t } from '../../i18n/translations';
 import styles from './Scoreboard.module.scss';
 
 /**
@@ -14,6 +15,7 @@ interface ScoreboardProps {
   skipped?: number;
   totalScore?: number;
   onSubmit?: () => void;
+  language?: string;
 }
 
 export function Scoreboard({
@@ -23,17 +25,18 @@ export function Scoreboard({
   skipped = 0,
   totalScore = 0,
   onSubmit,
+  language = 'en',
 }: ScoreboardProps) {
   const stats: Array<{ key: string; label: string; value: number; variant: string }> = [
-    { key: 'correct', label: 'Correct', value: correct, variant: styles.correct },
-    { key: 'incorrect', label: 'Incorrect', value: incorrect, variant: styles.incorrect },
-    { key: 'partial', label: 'Partial', value: partial, variant: styles.partial },
-    { key: 'skipped', label: 'Skipped', value: skipped, variant: styles.skipped },
+    { key: 'correct', label: t(language, 'CORRECT'), value: correct, variant: styles.correct },
+    { key: 'incorrect', label: t(language, 'INCORRECT'), value: incorrect, variant: styles.incorrect },
+    { key: 'partial', label: t(language, 'PARTIAL'), value: partial, variant: styles.partial },
+    { key: 'skipped', label: t(language, 'SKIPPED'), value: skipped, variant: styles.skipped },
   ];
 
   return (
-    <section className={styles.scoreboard} aria-label="Quiz Summary">
-      <h2 className={styles.heading}>Quiz Summary</h2>
+    <section className={styles.scoreboard} aria-label={t(language, 'QUIZ_SUMMARY')}>
+      <h2 className={styles.heading}>{t(language, 'QUIZ_SUMMARY')}</h2>
 
       <dl className={styles.stats}>
         {stats.map(({ key, label, value, variant }) => (
@@ -45,12 +48,12 @@ export function Scoreboard({
       </dl>
 
       <p className={styles.score}>
-        Score: <strong>{totalScore}</strong>
+        {t(language, 'SCORE')}: <strong>{totalScore}</strong>
       </p>
 
       {onSubmit && (
         <button type="button" className={styles.submit} onClick={onSubmit}>
-          Submit
+          {t(language, 'SUBMIT')}
         </button>
       )}
     </section>

--- a/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.module.scss
@@ -11,11 +11,46 @@
   @include m.mobile {
     padding: v.$space-6 v.$space-4;
   }
+
+  @include m.short {
+    padding: v.$space-3 v.$space-4;
+  }
+}
+
+// Groups the back link + card into a single column so `.wrap`'s existing
+// row-centering (over one child) still centers everything as a unit.
+.column {
+  width: 100%;
+  max-width: 800px;
+  display: flex;
+  flex-direction: column;
+}
+
+// Mirrors StartPage.module.scss .backBtn (back to Overview — the "first page").
+.backBtn {
+  @include m.focus-ring;
+
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: v.$space-1;
+  margin-bottom: v.$space-3;
+  padding: v.$space-1 0;
+  background: none;
+  border: none;
+  color: v.$gray-500;
+  font-family: v.$ff-base;
+  font-size: v.$text-sm;
+  font-weight: v.$fw-semibold;
+  cursor: pointer;
+
+  &:hover {
+    color: v.$g900;
+  }
 }
 
 .card {
   width: 100%;
-  max-width: 800px;
   background: v.$white;
   border-radius: v.$r-lg;
   box-shadow: v.$shadow-lg;
@@ -35,6 +70,11 @@
   @include m.mobile {
     padding: v.$space-6;
   }
+
+  @include m.short {
+    padding: v.$space-3;
+    gap: v.$space-3;
+  }
 }
 
 .bannerBadge {
@@ -49,6 +89,12 @@
   color: v.$white;
   font-size: v.$text-2xl;
   font-weight: v.$fw-bold;
+
+  @include m.short {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: v.$text-lg;
+  }
 }
 
 .bannerText {
@@ -70,6 +116,10 @@
   font-size: clamp(1.25rem, 3.5vw, #{v.$text-xl});
   font-weight: v.$fw-bold;
   color: v.$white;
+
+  @include m.short {
+    font-size: v.$text-md;
+  }
 }
 
 // Decorative translucent circle (top-right of the banner).
@@ -81,6 +131,10 @@
   height: 11rem;
   border-radius: v.$r-pill;
   background: rgba(255, 255, 255, 0.10);
+
+  @include m.short {
+    display: none;
+  }
 }
 
 // ── Body ─────────────────────────────────────────────────────────────────────
@@ -93,12 +147,21 @@
   @include m.mobile {
     padding: v.$space-5;
   }
+
+  @include m.short {
+    gap: v.$space-3;
+    padding: v.$space-3;
+  }
 }
 
 .instructions {
   padding: v.$space-6;
   background: v.$cream-bg;
   border-radius: v.$r-md;
+
+  @include m.short {
+    padding: v.$space-3;
+  }
 }
 
 .instructionsHeading {
@@ -108,6 +171,10 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: v.$gray-400;
+
+  @include m.short {
+    margin-bottom: v.$space-1;
+  }
 }
 
 .instructionsBody {
@@ -115,6 +182,10 @@
   font-size: v.$text-md;
   line-height: v.$lh-normal;
   color: v.$g700;
+
+  @include m.short {
+    font-size: v.$text-sm;
+  }
 }
 
 .startBtn {
@@ -138,5 +209,10 @@
 
   &:hover {
     background: v.$g800;
+  }
+
+  @include m.short {
+    padding: v.$space-3;
+    font-size: v.$text-base;
   }
 }

--- a/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.test.tsx
@@ -45,4 +45,24 @@ describe('SectionIntro', () => {
     fireEvent.click(screen.getByRole('button', { name: /start section b/i }));
     expect(onBegin).toHaveBeenCalledTimes(1);
   });
+
+  it('omits the Previous link when onPrevious is not provided', () => {
+    render(<SectionIntro section={section} sectionIndex={0} totalSections={3} onBegin={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /previous/i })).not.toBeInTheDocument();
+  });
+
+  it('emits onPrevious (back to the overview) from the Previous link', () => {
+    const onPrevious = vi.fn();
+    render(
+      <SectionIntro
+        section={section}
+        sectionIndex={0}
+        totalSections={3}
+        onBegin={vi.fn()}
+        onPrevious={onPrevious}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /previous/i }));
+    expect(onPrevious).toHaveBeenCalledTimes(1);
+  });
 });

--- a/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.tsx
+++ b/projects/sunbird-quml-player-react/src/components/SectionIntro/SectionIntro.tsx
@@ -1,4 +1,5 @@
 import { t, readI18n } from '../../i18n/translations';
+import { PreviousIcon } from '../icons';
 import type { Section } from '../../types';
 import styles from './SectionIntro.module.scss';
 
@@ -14,47 +15,67 @@ export interface SectionIntroProps {
   sectionIndex: number;
   totalSections: number;
   onBegin: () => void;
+  /** Back to the assessment overview (the "first page"). Renders a Previous link when set. */
   onPrevious?: () => void;
   language?: string;
 }
 
-export function SectionIntro({ section, sectionIndex, onBegin, language = 'en' }: SectionIntroProps) {
+export function SectionIntro({
+  section,
+  sectionIndex,
+  onBegin,
+  onPrevious,
+  language = 'en',
+}: SectionIntroProps) {
   const letter = String.fromCharCode(65 + sectionIndex);
   const questionCount = section.children?.length ?? 0;
   const instructions = readI18n(section.instructions, language) || t(language, 'MANDATORY_NOTE');
 
   return (
     <div className={styles.wrap}>
-      <article className={styles.card}>
-        <div className={styles.banner}>
-          <span className={styles.bannerBadge} aria-hidden="true">
-            {letter}
-          </span>
-          <div className={styles.bannerText}>
-            <p className={styles.bannerEyebrow}>
-              {t(language, 'SECTION')} {letter}
-            </p>
-            <h1 className={styles.bannerTitle}>
-              {questionCount} {t(language, 'QUESTIONS')}
-            </h1>
-          </div>
-          <span className={styles.bannerDeco} aria-hidden="true" />
-        </div>
-
-        <div className={styles.body}>
-          <div className={styles.instructions}>
-            <h2 className={styles.instructionsHeading}>{t(language, 'INSTRUCTIONS')}</h2>
-            <div
-              className={styles.instructionsBody}
-              dangerouslySetInnerHTML={{ __html: instructions }}
-            />
-          </div>
-
-          <button type="button" className={styles.startBtn} onClick={onBegin}>
-            {t(language, 'START_SECTION')} {letter} <span aria-hidden="true">→</span>
+      <div className={styles.column}>
+        {onPrevious && (
+          <button
+            type="button"
+            className={styles.backBtn}
+            onClick={onPrevious}
+            aria-label={t(language, 'PREVIOUS')}
+          >
+            <PreviousIcon size={16} /> {t(language, 'PREVIOUS')}
           </button>
-        </div>
-      </article>
+        )}
+
+        <article className={styles.card}>
+          <div className={styles.banner}>
+            <span className={styles.bannerBadge} aria-hidden="true">
+              {letter}
+            </span>
+            <div className={styles.bannerText}>
+              <p className={styles.bannerEyebrow}>
+                {t(language, 'SECTION')} {letter}
+              </p>
+              <h1 className={styles.bannerTitle}>
+                {questionCount} {t(language, 'QUESTIONS')}
+              </h1>
+            </div>
+            <span className={styles.bannerDeco} aria-hidden="true" />
+          </div>
+
+          <div className={styles.body}>
+            <div className={styles.instructions}>
+              <h2 className={styles.instructionsHeading}>{t(language, 'INSTRUCTIONS')}</h2>
+              <div
+                className={styles.instructionsBody}
+                dangerouslySetInnerHTML={{ __html: instructions }}
+              />
+            </div>
+
+            <button type="button" className={styles.startBtn} onClick={onBegin}>
+              {t(language, 'START_SECTION')} {letter} <span aria-hidden="true">→</span>
+            </button>
+          </div>
+        </article>
+      </div>
     </div>
   );
 }

--- a/projects/sunbird-quml-player-react/src/components/SectionPlayer/SectionPlayer.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/SectionPlayer/SectionPlayer.module.scss
@@ -9,6 +9,9 @@
   // whole player growing past a fixed-height host.
   height: 100%;
   min-height: 0;
+  // Positioning context for .navBtn in compact mode (see below) — harmless
+  // otherwise since nothing else in here is positioned.
+  position: relative;
 }
 
 // Shared centered column so the nav bar and question card line up 1:1.
@@ -32,10 +35,31 @@
   @include m.mobile {
     padding: v.$space-5 v.$space-4;
   }
+
+  @include m.short {
+    padding: v.$space-3 v.$space-4;
+
+    // On a short viewport most questions don't need the full height, so
+    // stretching the card to fill it just inflates the card's own blank
+    // interior. Let the card size to its content instead — any leftover
+    // space shows as the shell's background, not dead space inside a card.
+    > * {
+      flex: 0 1 auto;
+    }
+  }
+
+  // Compact (mobile-app) layout floats Prev/Next beside the card instead of in
+  // a top bar (see .navBtn below) — widen the inline gutter so they land
+  // beside the card, not over it.
+  @include m.compact {
+    padding-inline: 2.75rem;
+  }
 }
 
 // Question navigation, now at the TOP of the player (was a bottom footer).
 // Same max-width + gutters as .content so its edges align with the card.
+// Desktop/tablet/portal/editor: a normal top bar. Mobile-app only (m.compact,
+// below) — visually floats Prev/Next to the sides instead.
 .navBar {
   display: flex;
   align-items: center;
@@ -49,6 +73,10 @@
   @include m.mobile {
     padding: v.$space-3 v.$space-4;
   }
+
+  @include m.short {
+    padding: v.$space-2 v.$space-4;
+  }
 }
 
 .counter {
@@ -58,6 +86,12 @@
   color: v.$g600;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+
+  // Mobile-app only: replaced by QuestionCard's progress badge next to the
+  // question-type tag (see QuestionCard.module.scss .progress).
+  @include m.compact {
+    display: none;
+  }
 }
 
 .navBtn {
@@ -87,10 +121,49 @@
     min-width: 2.75rem;
     min-height: 2.75rem;
   }
+
+  // Mobile-app only: float beside the card, vertically centered on the
+  // section's full height (`.sectionPlayer`, not `.navBar`), icon-only circle.
+  // Desktop/tablet/portal/editor are untouched — this rule only fires under
+  // m.compact.
+  @include m.compact {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 5;
+    min-width: 0;
+    min-height: 0;
+    width: 2.25rem;
+    height: 2.25rem;
+    padding: 0;
+    border-radius: v.$r-pill;
+
+    // The base hover lift (translateY(-1px)) would fight the centering
+    // transform above — keep the shadow/color feedback, drop the lift.
+    &:hover:not(:disabled) {
+      transform: translateY(-50%);
+    }
+  }
+}
+
+.navPrev {
+  @include m.compact {
+    left: v.$space-1;
+  }
+}
+
+.navNext {
+  @include m.compact {
+    right: v.$space-1;
+  }
 }
 
 .navLabel {
   @include m.mobile {
+    display: none;
+  }
+
+  @include m.compact {
     display: none;
   }
 }

--- a/projects/sunbird-quml-player-react/src/components/SectionPlayer/SectionPlayer.tsx
+++ b/projects/sunbird-quml-player-react/src/components/SectionPlayer/SectionPlayer.tsx
@@ -201,7 +201,7 @@ export function SectionPlayer({ section, onSectionEnd, isLastSection = true }: S
       <div className={styles.navBar}>
         <button
           type="button"
-          className={styles.navBtn}
+          className={`${styles.navBtn} ${styles.navPrev}`}
           onClick={handlePrevious}
           disabled={isFirst}
           aria-label={t(language, 'PREVIOUS')}
@@ -210,6 +210,8 @@ export function SectionPlayer({ section, onSectionEnd, isLastSection = true }: S
           <span className={styles.navLabel}>{t(language, 'PREVIOUS')}</span>
         </button>
 
+        {/* Desktop/tablet only (hidden in compact mode via QuestionCard's
+            progress badge) — kept here so the counter stays centered. */}
         <span className={styles.counter}>
           {t(language, 'QUESTION')} {currentSlide + 1} {t(language, 'OF')} {questions.length}
         </span>
@@ -222,7 +224,7 @@ export function SectionPlayer({ section, onSectionEnd, isLastSection = true }: S
           // non-interactive (aria-hidden, not focusable, disabled).
           <button
             type="button"
-            className={styles.navBtn}
+            className={`${styles.navBtn} ${styles.navNext}`}
             style={{ visibility: 'hidden' }}
             aria-hidden="true"
             tabIndex={-1}
@@ -236,7 +238,7 @@ export function SectionPlayer({ section, onSectionEnd, isLastSection = true }: S
           // when on a section's last question.
           <button
             type="button"
-            className={styles.navBtn}
+            className={`${styles.navBtn} ${styles.navNext}`}
             onClick={isLast ? handleSubmit : handleNext}
             // Last question: enabled once answered (or section is skippable) so the
             // learner can move to the next section. Otherwise gate on canAdvance.
@@ -250,7 +252,11 @@ export function SectionPlayer({ section, onSectionEnd, isLastSection = true }: S
       </div>
 
       <div className={styles.content} ref={contentRef}>
-        <QuestionCard question={currentQuestion} meta={{ category: currentQuestion.primaryCategory }}>
+        <QuestionCard
+          question={currentQuestion}
+          meta={{ category: currentQuestion.primaryCategory }}
+          progress={{ current: currentSlide + 1, total: questions.length }}
+        >
           <QuestionRenderer
             key={currentQuestion.identifier}
             question={currentQuestion}

--- a/projects/sunbird-quml-player-react/src/components/StartPage/StartPage.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/StartPage/StartPage.module.scss
@@ -17,6 +17,23 @@
   @include m.mobile {
     padding: v.$space-5 v.$space-4;
   }
+
+  @include m.short {
+    padding: v.$space-4 v.$space-4;
+  }
+
+  // Mobile-app only — a plain white page instead of the cream backdrop, so it
+  // doesn't read as a separate "card" floating on a page (both screens paged
+  // via StartPage.tsx `step` share this background). Also a flex column with
+  // a real height (not just min-height) so `.screenInfo`/`.screenSections`
+  // below can flex:1 to fill it — and a positioning context for `.nextBtn`.
+  @include m.compact {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    background: v.$white;
+    position: relative;
+  }
 }
 
 // ── Letter badge ─────────────────────────────────────────────────────────────
@@ -39,6 +56,38 @@
   min-width: 0;
   max-width: 920px;
   margin-inline: auto;
+
+  @include m.compact {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+}
+
+// Mobile-app-only wrapper (see StartPage.tsx) — a flex column so `.statsCard`
+// below can flex:1 and fill the rest of the screen, instead of sizing to its
+// own content and leaving blank page beneath it.
+.screenInfo {
+  @include m.compact {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
+}
+
+// Mobile-app-only wrapper — a flex column where `.grid` (not the whole
+// screen) is the flex:1/scrollable piece, so the Start/Resume CTA + footer
+// note stay pinned at the bottom and stay reachable without scrolling no
+// matter how many sections there are; only the grid between them scrolls.
+.screenSections {
+  @include m.compact {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+  }
 }
 
 .heading {
@@ -47,6 +96,10 @@
   justify-content: space-between;
   gap: v.$space-6;
   margin-bottom: v.$space-10;
+
+  @include m.short {
+    margin-bottom: v.$space-4;
+  }
 }
 
 .headingText {
@@ -59,6 +112,11 @@
   font-weight: v.$fw-bold;
   line-height: v.$lh-tight;
   color: v.$g900;
+
+  @include m.short {
+    margin-bottom: v.$space-2;
+    font-size: v.$text-xl;
+  }
 }
 
 // Decorative stacked cards (top-right of the title).
@@ -69,6 +127,10 @@
   height: 4.5rem;
 
   @include m.mobile {
+    display: none;
+  }
+
+  @include m.short {
     display: none;
   }
 }
@@ -118,6 +180,22 @@
     padding: v.$space-5 v.$space-3;
     gap: v.$space-4;
   }
+
+  @include m.short {
+    margin-bottom: v.$space-4;
+    padding: v.$space-3;
+    gap: v.$space-2;
+  }
+
+  // Fill the rest of the screen (see `.screenInfo`) instead of sizing to its
+  // own content. `space-evenly` distributes the extra height as equal gaps
+  // above the first row, between the rows, and below the last row — `center`
+  // left the inter-row gap much smaller than the card's top/bottom margins.
+  @include m.compact {
+    flex: 1;
+    margin-bottom: 0;
+    align-content: space-evenly;
+  }
 }
 
 .stat {
@@ -141,6 +219,11 @@
     gap: v.$space-3;
     padding: 0 v.$space-2;
   }
+
+  @include m.short {
+    gap: v.$space-2;
+    padding: 0;
+  }
 }
 
 .statIcon {
@@ -157,6 +240,11 @@
   @include m.mobile {
     width: 2.25rem;
     height: 2.25rem;
+  }
+
+  @include m.short {
+    width: 1.75rem;
+    height: 1.75rem;
   }
 }
 
@@ -182,20 +270,56 @@
   font-weight: v.$fw-bold;
   color: v.$g900;
   font-variant-numeric: tabular-nums;
+
+  @include m.short {
+    font-size: v.$text-base;
+  }
 }
 
 // ── Sections grid ────────────────────────────────────────────────────────────
+// Mobile-app only (see StartPage.tsx `isCompact`/`step`) — back to the stats
+// screen. Desktop/tablet never render this (both screens show at once there).
+.backBtn {
+  @include m.focus-ring;
+
+  display: inline-flex;
+  align-items: center;
+  gap: v.$space-1;
+  margin-bottom: v.$space-3;
+  padding: v.$space-1 0;
+  background: none;
+  border: none;
+  color: v.$gray-500;
+  font-family: v.$ff-base;
+  font-size: v.$text-sm;
+  font-weight: v.$fw-semibold;
+  cursor: pointer;
+
+  &:hover {
+    color: v.$g900;
+  }
+}
+
 .sectionsHeading {
   margin: 0 0 v.$space-2;
   font-size: v.$text-xl;
   font-weight: v.$fw-bold;
   color: v.$g900;
+
+  @include m.short {
+    font-size: v.$text-md;
+  }
 }
 
 .sectionsNote {
   margin: 0 0 v.$space-6;
   font-size: v.$text-base;
   color: v.$gray-500;
+
+  @include m.short {
+    margin-bottom: v.$space-3;
+    font-size: v.$text-sm;
+  }
 }
 
 .grid {
@@ -212,6 +336,26 @@
   @include m.mobile {
     grid-template-columns: minmax(0, 1fr);
   }
+
+  // A short viewport (landscape phone) has width to spare even when the width
+  // tier above reads "mobile" — go back to 2-up so cards size to their content
+  // instead of stretching full-width with a single short line of text and lots
+  // of trailing blank space, and to use fewer rows (less height needed).
+  @include m.short {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: v.$space-2;
+    margin-bottom: v.$space-4;
+  }
+
+  // The scrollable middle of `.screenSections`: however many sections there
+  // are, this is the only part that scrolls — the heading above and the
+  // Start/Resume CTA + footer note below stay pinned and always reachable.
+  @include m.compact {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    margin-bottom: v.$space-3;
+  }
 }
 
 .sectionCard {
@@ -227,6 +371,11 @@
   text-align: start;
   font-family: v.$ff-base;
   transition: box-shadow v.$dur-fast v.$ease-out, transform v.$dur-fast v.$ease-out;
+
+  @include m.short {
+    gap: v.$space-1;
+    padding: v.$space-3;
+  }
 }
 
 button.sectionCard {
@@ -266,6 +415,10 @@ button.sectionCard {
 .cardBlurb {
   font-size: v.$text-sm;
   color: v.$gray-500;
+
+  @include m.short {
+    display: none;
+  }
 }
 
 // ── CTA + footer ─────────────────────────────────────────────────────────────
@@ -291,6 +444,41 @@ button.sectionCard {
   &:hover {
     background: v.$brick-shade;
   }
+
+  @include m.short {
+    padding: v.$space-2 v.$space-3;
+    font-size: v.$text-sm;
+  }
+}
+
+// Mobile-app-only "Next" (screen 1 → screen 2, see StartPage.tsx `step`) — a
+// small pill floating over the stats card's bottom-right corner, not a
+// full-width bar, since it's a secondary "continue" action, not the main
+// Start/Resume CTA.
+.nextBtn {
+  @include m.focus-ring($color: v.$ink);
+
+  position: absolute;
+  right: v.$space-4;
+  bottom: v.$space-4;
+  display: inline-flex;
+  align-items: center;
+  gap: v.$space-1;
+  padding: v.$space-2 v.$space-4;
+  border: none;
+  border-radius: v.$r-pill;
+  background: v.$brick;
+  color: v.$white;
+  font-family: v.$ff-base;
+  font-size: v.$text-sm;
+  font-weight: v.$fw-semibold;
+  cursor: pointer;
+  box-shadow: v.$shadow-md;
+  transition: background v.$dur-fast v.$ease-out;
+
+  &:hover {
+    background: v.$brick-shade;
+  }
 }
 
 .footerNote {
@@ -301,6 +489,10 @@ button.sectionCard {
   margin: v.$space-5 0 0;
   font-size: v.$text-sm;
   color: v.$gray-500;
+
+  @include m.short {
+    margin-top: v.$space-2;
+  }
 }
 
 .footerIcon {

--- a/projects/sunbird-quml-player-react/src/components/StartPage/StartPage.test.tsx
+++ b/projects/sunbird-quml-player-react/src/components/StartPage/StartPage.test.tsx
@@ -45,9 +45,15 @@ describe('StartPage', () => {
     expect(screen.queryByText(/progress is saved/i)).not.toBeInTheDocument();
   });
 
-  it('omits the minutes tile when there is no time limit', () => {
-    render(<StartPage {...baseProps} timeLimit={0} />);
-    expect(screen.queryByText(/minutes/i)).not.toBeInTheDocument();
+  it('shows "No Limit" for the minutes tile when there is no time limit', () => {
+    render(<StartPage {...baseProps} timeLimit={0} attemptsLeft={3} />);
+    expect(screen.getByText(/minutes/i)).toBeInTheDocument();
+    expect(screen.getByText('No Limit')).toBeInTheDocument();
+  });
+
+  it('shows "No Limit" attempts when the backend does not send a cap', () => {
+    render(<StartPage {...baseProps} attemptsLeft={null} />);
+    expect(screen.getAllByText('No Limit').length).toBeGreaterThanOrEqual(1);
   });
 
   it('emits onStart when the CTA is clicked', () => {

--- a/projects/sunbird-quml-player-react/src/components/StartPage/StartPage.tsx
+++ b/projects/sunbird-quml-player-react/src/components/StartPage/StartPage.tsx
@@ -1,3 +1,4 @@
+import { useRef, useState } from 'react';
 import { t, readI18n } from '../../i18n/translations';
 import {
   ClipboardIcon,
@@ -6,17 +7,25 @@ import {
   AttemptsIcon,
   ChevronRightIcon,
   ShieldIcon,
+  PreviousIcon,
 } from '../icons';
 import type { Section } from '../../types';
+import { useIsCompactViewport } from './useIsCompactViewport';
 import styles from './StartPage.module.scss';
 
 /**
  * StartPage — Assessment Overview / details screen (spec §6.1 + §6.2).
  *
- * Pure presentational: a centered column with the assessment identity, a stats
- * card, an "assessment sections" grid, and a Start CTA. All data is derived by
- * MainPlayer from Context and passed as props; this component owns no runtime
- * state and never mutates Context.
+ * A centered column with the assessment identity, a stats card, an
+ * "assessment sections" grid, and a Start CTA. All data is derived by
+ * MainPlayer from Context and passed as props; this component never mutates
+ * Context.
+ *
+ * Desktop/tablet/portal/editor: everything renders on one scrollable page
+ * (unchanged). Mobile-app only (`useIsCompactViewport`): paged into two
+ * screens — stats first, then sections + the Start/Resume CTA — so neither
+ * screen needs to scroll on a short/narrow viewport. This is the one bit of
+ * local UI state in this component; it never reaches Context or the parent.
  */
 
 /** Letter-badge palette for the first sections (later sections render without a badge). */
@@ -27,9 +36,14 @@ export interface StartPageProps {
   sections: Section[];
   totalQuestions: number;
   totalSections: number;
-  /** Seconds; omit/0 hides the minutes value. */
+  /** Seconds; omit/0 shows "No Limit" instead of a duration. */
   timeLimit?: number;
-  attemptsLeft?: number;
+  /** Omit/null → "No Limit" (the backend didn't send a cap), distinct from an explicit low number. */
+  attemptsLeft?: number | null;
+  /** True once the assessment has already been entered this attempt (e.g. via
+   * the header brand button) — the clock keeps running behind Overview, so the
+   * CTA and footer note should read "Resume", not "Start". */
+  hasStarted?: boolean;
   onStart: () => void;
   /** Optional jump-to-section from a section card (defaults to Start). */
   onSectionSelect?: (index: number) => void;
@@ -49,95 +63,144 @@ export function StartPage({
   totalQuestions,
   totalSections,
   timeLimit = 0,
-  attemptsLeft = 3,
+  attemptsLeft = null,
+  hasStarted = false,
   onStart,
   onSectionSelect,
   language = 'en',
 }: StartPageProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isCompact = useIsCompactViewport(containerRef);
+  const [step, setStep] = useState<'info' | 'sections'>('info');
+  // Non-compact always shows both; compact gates on `step`.
+  const showInfo = !isCompact || step === 'info';
+  const showSections = !isCompact || step === 'sections';
+
   const questionLabel = (n: number) =>
     `${n} ${n === 1 ? t(language, 'QUESTION').toLowerCase() : t(language, 'QUESTIONS').toLowerCase()}`;
 
+  // Not sent by the backend → "No Limit" rather than hiding the tile or
+  // showing a fabricated number.
+  const attemptsDisplay = attemptsLeft == null ? t(language, 'NO_LIMIT') : String(attemptsLeft);
+
   const stats = [
     { key: 'q', icon: <ClipboardIcon size={20} />, label: t(language, 'QUESTIONS'), value: String(totalQuestions) },
-    // No time limit → omit the tile entirely (nothing meaningful to show).
-    ...(timeLimit > 0
-      ? [{ key: 'm', icon: <TimerIcon size={20} />, label: t(language, 'MINUTES_LABEL'), value: formatMinutes(timeLimit) }]
-      : []),
+    {
+      key: 'm',
+      icon: <TimerIcon size={20} />,
+      label: t(language, 'MINUTES_LABEL'),
+      value: timeLimit > 0 ? formatMinutes(timeLimit) : t(language, 'NO_LIMIT'),
+    },
     { key: 's', icon: <GridIcon size={20} />, label: t(language, 'SECTIONS'), value: String(totalSections) },
-    { key: 'a', icon: <AttemptsIcon size={20} />, label: t(language, 'ATTEMPTS_LEFT'), value: String(attemptsLeft) },
+    { key: 'a', icon: <AttemptsIcon size={20} />, label: t(language, 'ATTEMPTS_LEFT'), value: attemptsDisplay },
   ];
 
   return (
-    <div className={styles.overview}>
+    <div className={styles.overview} ref={containerRef}>
       <main className={styles.main}>
-        <div className={styles.heading}>
-          <div className={styles.headingText}>
-            <h1 className={styles.title}>{title}</h1>
-          </div>
-          <span className={styles.decoCards} aria-hidden="true">
-            <span className={styles.decoCard} />
-            <span className={styles.decoCard} />
-            <span className={styles.decoCard} />
-          </span>
-        </div>
-
-        <dl className={styles.statsCard}>
-          {stats.map(({ key, icon, label, value }) => (
-            <div key={key} className={styles.stat}>
-              <span className={styles.statIcon}>{icon}</span>
-              <div className={styles.statText}>
-                <dt className={styles.statLabel}>{label}</dt>
-                <dd className={styles.statValue}>{value}</dd>
+        {showInfo && (
+          // Mobile-app only: this whole block is a flex column filling the
+          // screen — .statsCard is flex:1, so the card itself fills the
+          // remaining height instead of leaving blank page below it.
+          <div className={styles.screenInfo}>
+            <div className={styles.heading}>
+              <div className={styles.headingText}>
+                <h1 className={styles.title}>{title}</h1>
               </div>
+              <span className={styles.decoCards} aria-hidden="true">
+                <span className={styles.decoCard} />
+                <span className={styles.decoCard} />
+                <span className={styles.decoCard} />
+              </span>
             </div>
-          ))}
-        </dl>
 
-        <h2 className={styles.sectionsHeading}>{t(language, 'ASSESSMENT_SECTIONS')}</h2>
-        <p className={styles.sectionsNote}>{t(language, 'SECTIONS_COVER_NOTE')}</p>
-
-        <div className={styles.grid}>
-          {sections.map((section, i) => {
-            const blurb = readI18n(section.description, language);
-            const name = readI18n(section.name, language);
-            const Tag = onSectionSelect ? 'button' : 'div';
-            return (
-              <Tag
-                key={section.identifier}
-                className={styles.sectionCard}
-                {...(onSectionSelect
-                  ? { type: 'button' as const, onClick: () => onSectionSelect(i) }
-                  : {})}
-              >
-                <div className={styles.cardTop}>
-                  {i < BADGE_COLORS.length && (
-                    <span
-                      className={styles.badge}
-                      style={{ background: BADGE_COLORS[i] }}
-                      aria-hidden="true"
-                    >
-                      {String.fromCharCode(65 + i)}
-                    </span>
-                  )}
-                  <span className={styles.cardName}>{name}</span>
-                  <ChevronRightIcon size={18} className={styles.cardChevron} />
+            <dl className={styles.statsCard}>
+              {stats.map(({ key, icon, label, value }) => (
+                <div key={key} className={styles.stat}>
+                  <span className={styles.statIcon}>{icon}</span>
+                  <div className={styles.statText}>
+                    <dt className={styles.statLabel}>{label}</dt>
+                    <dd className={styles.statValue}>{value}</dd>
+                  </div>
                 </div>
-                <span className={styles.cardCount}>{questionLabel(section.children.length)}</span>
-                {blurb && <span className={styles.cardBlurb}>{blurb}</span>}
-              </Tag>
-            );
-          })}
-        </div>
+              ))}
+            </dl>
+          </div>
+        )}
 
-        <button type="button" className={styles.startBtn} onClick={onStart}>
-          {t(language, 'START_ASSESSMENT')} <span aria-hidden="true">→</span>
-        </button>
+        {showSections && (
+          // Mobile-app only: also a flex column, but the SECTION GRID is the
+          // flex:1/scrollable piece (not the whole screen) — heading/note stay
+          // pinned at top and the Start/Resume CTA + footer note stay pinned
+          // at the bottom, so the CTA is always reachable without scrolling
+          // even with many sections; only the grid between them scrolls.
+          <div className={styles.screenSections}>
+            {isCompact && (
+              <button
+                type="button"
+                className={styles.backBtn}
+                onClick={() => setStep('info')}
+                aria-label={t(language, 'PREVIOUS')}
+              >
+                <PreviousIcon size={16} /> {t(language, 'PREVIOUS')}
+              </button>
+            )}
 
-        <p className={styles.footerNote}>
-          <ShieldIcon size={16} className={styles.footerIcon} />
-          {t(language, 'TIMER_START_NOTE', { attempts: attemptsLeft })}
-        </p>
+            <h2 className={styles.sectionsHeading}>{t(language, 'ASSESSMENT_SECTIONS')}</h2>
+            <p className={styles.sectionsNote}>{t(language, 'SECTIONS_COVER_NOTE')}</p>
+
+            <div className={styles.grid}>
+              {sections.map((section, i) => {
+                const blurb = readI18n(section.description, language);
+                const name = readI18n(section.name, language);
+                const Tag = onSectionSelect ? 'button' : 'div';
+                return (
+                  <Tag
+                    key={section.identifier}
+                    className={styles.sectionCard}
+                    {...(onSectionSelect
+                      ? { type: 'button' as const, onClick: () => onSectionSelect(i) }
+                      : {})}
+                  >
+                    <div className={styles.cardTop}>
+                      {i < BADGE_COLORS.length && (
+                        <span
+                          className={styles.badge}
+                          style={{ background: BADGE_COLORS[i] }}
+                          aria-hidden="true"
+                        >
+                          {String.fromCharCode(65 + i)}
+                        </span>
+                      )}
+                      <span className={styles.cardName}>{name}</span>
+                      <ChevronRightIcon size={18} className={styles.cardChevron} />
+                    </div>
+                    <span className={styles.cardCount}>{questionLabel(section.children.length)}</span>
+                    {blurb && <span className={styles.cardBlurb}>{blurb}</span>}
+                  </Tag>
+                );
+              })}
+            </div>
+
+            <button type="button" className={styles.startBtn} onClick={onStart}>
+              {t(language, hasStarted ? 'RESUME_ASSESSMENT' : 'START_ASSESSMENT')} <span aria-hidden="true">→</span>
+            </button>
+
+            <p className={styles.footerNote}>
+              <ShieldIcon size={16} className={styles.footerIcon} />
+              {t(language, hasStarted ? 'TIMER_RESUME_NOTE' : 'TIMER_START_NOTE', { attempts: attemptsDisplay })}
+            </p>
+          </div>
+        )}
       </main>
+
+      {/* Mobile-app only — a small floating "Next" over the info screen's
+          bottom-right corner (screen 1 → screen 2, see `step` above). */}
+      {isCompact && showInfo && (
+        <button type="button" className={styles.nextBtn} onClick={() => setStep('sections')}>
+          {t(language, 'NEXT')} <span aria-hidden="true">→</span>
+        </button>
+      )}
     </div>
   );
 }

--- a/projects/sunbird-quml-player-react/src/components/StartPage/useIsCompactViewport.ts
+++ b/projects/sunbird-quml-player-react/src/components/StartPage/useIsCompactViewport.ts
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import type { RefObject } from 'react';
+
+// Mirrors the SCSS `m.compact` mixin (styles/mixins.scss) — narrow width OR
+// short height. Kept in sync manually: SCSS can't export tokens to JS, and
+// this is the one piece of "mobile-app-only" behavior that can't be done in
+// pure CSS (it changes what's IN the DOM — paging the overview into two
+// screens — not just how existing DOM looks).
+const MOBILE_MAX_WIDTH = 768;
+const SHORT_MAX_HEIGHT = 720;
+
+/**
+ * True when the player is effectively rendering as the mobile app — narrow
+ * width (container-based, so it also matches the editor's mobile preview) OR
+ * a short viewport (a real device in landscape). False on portal/desktop/
+ * editor-desktop-preview, where nothing here should change behavior.
+ */
+export function useIsCompactViewport(containerRef: RefObject<HTMLElement>): boolean {
+  const [isCompact, setIsCompact] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    // Both are unavailable under jsdom (no test env implements viewport
+    // layout anyway) — fall back to the default `false` (today's single-page
+    // layout), which is what every existing test already renders against.
+    if (!el || typeof ResizeObserver === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const heightQuery = window.matchMedia(`(max-height: ${SHORT_MAX_HEIGHT}px)`);
+    const update = () => {
+      const width = el.getBoundingClientRect().width;
+      setIsCompact(width <= MOBILE_MAX_WIDTH || heightQuery.matches);
+    };
+
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    heightQuery.addEventListener('change', update);
+    update();
+
+    return () => {
+      ro.disconnect();
+      heightQuery.removeEventListener('change', update);
+    };
+  }, [containerRef]);
+
+  return isCompact;
+}

--- a/projects/sunbird-quml-player-react/src/components/questions/ReoQuestion/ReoQuestion.module.scss
+++ b/projects/sunbird-quml-player-react/src/components/questions/ReoQuestion/ReoQuestion.module.scss
@@ -91,6 +91,12 @@
   font-size: v.$text-sm;
   font-weight: v.$fw-medium;
   cursor: grab;
+  // Touch drag: prevent the webview from consuming the finger-drag as a scroll
+  // so react-dnd's TouchBackend receives the move (else the chip won't move on
+  // mobile).
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
 
   &:hover:not(:disabled) {
     border-color: v.$brick;

--- a/projects/sunbird-quml-player-react/src/dev/sample-data.ts
+++ b/projects/sunbird-quml-player-react/src/dev/sample-data.ts
@@ -10,7 +10,10 @@ import type { PlayerConfig } from '../types';
  */
 export const sampleConfig: PlayerConfig = {
   context: { uid: 'dev-user', sid: 'dev-session', channel: 'dev' },
-  config: { language: 'en', showFeedback: true, maxAttempts: 3 },
+  config: { language: 'en', showFeedback: true },
+  // maxAttempts is host/backend data (Angular parity: playerConfig.metadata),
+  // not a player UI setting.
+  metadata: { maxAttempts: 3 },
   data: {
     identifier: 'do_sample_set',
     name: 'Sunbird Assessment',

--- a/projects/sunbird-quml-player-react/src/i18n/translations-ar.ts
+++ b/projects/sunbird-quml-player-react/src/i18n/translations-ar.ts
@@ -38,6 +38,7 @@ export const translations: Record<string, string> = {
   MINUTES: 'دقائق',
 
   // Scoring
+  QUIZ_SUMMARY: 'ملخّص الاختبار',
   SCORE: 'الدرجة',
   TOTAL_SCORE: 'الدرجة الكلية',
   CORRECT: 'صحيح',
@@ -95,9 +96,12 @@ export const translations: Record<string, string> = {
   ASSESSMENT_SECTIONS: 'أقسام التقييم',
   SECTIONS_COVER_NOTE: 'إليك ما ستغطّيه في هذا التقييم.',
   START_ASSESSMENT: 'بدء التقييم',
+  RESUME_ASSESSMENT: 'استئناف التقييم',
   ATTEMPTS_LEFT: 'المحاولات المتبقية',
   MINUTES_LABEL: 'دقائق',
+  NO_LIMIT: 'بلا حدّ',
   TIMER_START_NOTE: 'يبدأ المؤقّت عند النقر. لديك {attempts} محاولات لهذا التقييم.',
+  TIMER_RESUME_NOTE: 'المؤقّت ما زال يعمل. لديك {attempts} محاولات لهذا التقييم.',
 
   // Assessment shell header / section intro (Phase 6 design)
   START_SECTION: 'بدء القسم',

--- a/projects/sunbird-quml-player-react/src/i18n/translations-en.ts
+++ b/projects/sunbird-quml-player-react/src/i18n/translations-en.ts
@@ -35,6 +35,7 @@ export const translations: Record<string, string> = {
   MINUTES: 'minutes',
 
   // Scoring
+  QUIZ_SUMMARY: 'Quiz Summary',
   SCORE: 'Score',
   TOTAL_SCORE: 'Total Score',
   CORRECT: 'Correct',
@@ -92,9 +93,12 @@ export const translations: Record<string, string> = {
   ASSESSMENT_SECTIONS: 'Assessment sections',
   SECTIONS_COVER_NOTE: "Here's what you'll be covering in this assessment.",
   START_ASSESSMENT: 'Start assessment',
+  RESUME_ASSESSMENT: 'Resume assessment',
   ATTEMPTS_LEFT: 'Attempts Left',
   MINUTES_LABEL: 'Minutes',
+  NO_LIMIT: 'No Limit',
   TIMER_START_NOTE: 'The timer starts when you click. You have {attempts} attempts for this assessment.',
+  TIMER_RESUME_NOTE: 'Your timer is still running. You have {attempts} attempts for this assessment.',
 
   // Assessment shell header / section intro (Phase 6 design)
   START_SECTION: 'Start section',

--- a/projects/sunbird-quml-player-react/src/i18n/translations-fr.ts
+++ b/projects/sunbird-quml-player-react/src/i18n/translations-fr.ts
@@ -38,6 +38,7 @@ export const translations: Record<string, string> = {
   MINUTES: 'minutes',
 
   // Scoring
+  QUIZ_SUMMARY: 'Résumé du quiz',
   SCORE: 'Score',
   TOTAL_SCORE: 'Score total',
   CORRECT: 'Correct',
@@ -95,10 +96,14 @@ export const translations: Record<string, string> = {
   ASSESSMENT_SECTIONS: 'Sections de l’évaluation',
   SECTIONS_COVER_NOTE: 'Voici ce que vous allez aborder dans cette évaluation.',
   START_ASSESSMENT: 'Commencer l’évaluation',
+  RESUME_ASSESSMENT: 'Reprendre l’évaluation',
   ATTEMPTS_LEFT: 'Tentatives restantes',
   MINUTES_LABEL: 'Minutes',
+  NO_LIMIT: 'Sans limite',
   TIMER_START_NOTE:
     'Le minuteur démarre lorsque vous cliquez. Vous avez {attempts} tentatives pour cette évaluation.',
+  TIMER_RESUME_NOTE:
+    'Votre minuteur est toujours en cours. Vous avez {attempts} tentatives pour cette évaluation.',
 
   // Assessment shell header / section intro (Phase 6 design)
   START_SECTION: 'Commencer la section',

--- a/projects/sunbird-quml-player-react/src/i18n/translations-pt.ts
+++ b/projects/sunbird-quml-player-react/src/i18n/translations-pt.ts
@@ -38,6 +38,7 @@ export const translations: Record<string, string> = {
   MINUTES: 'minutos',
 
   // Scoring
+  QUIZ_SUMMARY: 'Resumo do questionário',
   SCORE: 'Pontuação',
   TOTAL_SCORE: 'Pontuação total',
   CORRECT: 'Correto',
@@ -95,10 +96,14 @@ export const translations: Record<string, string> = {
   ASSESSMENT_SECTIONS: 'Seções da avaliação',
   SECTIONS_COVER_NOTE: 'Veja o que você abordará nesta avaliação.',
   START_ASSESSMENT: 'Iniciar avaliação',
+  RESUME_ASSESSMENT: 'Continuar avaliação',
   ATTEMPTS_LEFT: 'Tentativas restantes',
   MINUTES_LABEL: 'Minutos',
+  NO_LIMIT: 'Sem limite',
   TIMER_START_NOTE:
     'O cronômetro começa quando você clica. Você tem {attempts} tentativas para esta avaliação.',
+  TIMER_RESUME_NOTE:
+    'Seu cronômetro continua em execução. Você tem {attempts} tentativas para esta avaliação.',
 
   // Assessment shell header / section intro (Phase 6 design)
   START_SECTION: 'Iniciar seção',

--- a/projects/sunbird-quml-player-react/src/styles/mixins.scss
+++ b/projects/sunbird-quml-player-react/src/styles/mixins.scss
@@ -34,6 +34,37 @@
   }
 }
 
+// Respond to a short viewport (e.g. a phone in landscape), regardless of width.
+// `.appShell`'s container is `inline-size`-only (see its comment), so width
+// tiers above can't see height at all — a landscape phone can be "desktop" or
+// "tablet" width while its actual height is a fraction of a portrait phone's,
+// pushing primary CTAs (e.g. "Start assessment") below the fold. This is a real
+// `@media` height query (not `@container`), because block-size containment
+// isn't set up (doing so risks the height:100% chain — see the freeze-fix
+// history) and, on real devices, the player fills the viewport anyway so
+// viewport height == available height.
+@mixin short {
+  @media (max-height: #{v.$bp-short-height}) {
+    @content;
+  }
+}
+
+// "Are we effectively the mobile app" — narrow width OR short height. A real
+// device is one or the other depending on orientation (portrait → narrow,
+// landscape → short), while portal/desktop/editor stay comfortably outside
+// both. Use this instead of `mobile`/`short` individually for changes that
+// should be mobile-app-only and must NOT show up on desktop/portal/editor at
+// any orientation. `@container` and `@media` can't be OR'd in one rule, so
+// this just repeats @content under each condition.
+@mixin compact {
+  @include mobile {
+    @content;
+  }
+  @include short {
+    @content;
+  }
+}
+
 // Accessible focus ring — white halo + primary outline (keyboard focus).
 @mixin focus-ring($color: v.$brick) {
   outline: none;

--- a/projects/sunbird-quml-player-react/src/styles/variables.scss
+++ b/projects/sunbird-quml-player-react/src/styles/variables.scss
@@ -112,3 +112,4 @@ $sidebar-w:  280px;
 $header-h:   4rem;
 $bp-mobile:  768px;
 $bp-tablet:  1024px; // tablet/laptop boundary — ≤1023px is "tablet and below"
+$bp-short-height: 720px; // landscape-phone height boundary — see m.short


### PR DESCRIPTION
## Summary

  Two commits: mobile-app "compact" viewport layout (paged overview, floating nav on question/review screens, tighter
  spacing) + attempt-limit/results-screen parity fixes (`maxAttempts`, `summaryType`, `showTimer`).

  ## What changed

  **Mobile-app only** (desktop/portal/editor unaffected):
  - `StartPage` paged into two screens (stats → sections) instead of one long scroll
  - Prev/Next on question/review screens are now floating side buttons, not a top bar
  - Section-intro banner replaced by a compact navbar label; instructions scroll internally
  - Added a working "back to overview" link on section-intro (prop existed, was never wired up)

  **Everywhere:**
  - "No Limit" shown instead of hiding/faking a value when timer or attempts aren't sent
  - `maxAttempts` now read from the correct field (`metadata`, not `config`) — Retake is hidden once attempts are
  exhausted (previously always unlimited)
  - `summaryType` (`Complete`/`Score`/`Duration`/`Score and Duration`) now actually gates score/duration on the results
  screen — was completely ignored before
  - Fixed `showTimer` incorrectly blocking internal time tracking: a hidden timer now still enforces its time limit
  (auto-submits) and still reports duration on results — previously both were silently broken when the timer widget was
  hidden
  - `Scoreboard` labels are now translated (were hardcoded English)

  ## Testing

  `tsc -b` clean; 358/358 tests passing. New tests cover max-attempts/Retake gating, the `exdata` host event,
  `s